### PR TITLE
Feet mounted endstops

### DIFF
--- a/openscad/endstop.scad
+++ b/openscad/endstop.scad
@@ -10,10 +10,10 @@ module endstop_switch(){
 }
 
 module endstop_hole(tilt){
-    translate([4.3,-2.4,-1])rotate([0,180,0]){
+    translate([4.3,-2.4,-2.9])rotate([0,180,0]){
         translate([-1.3,0,-3])cube([11.4,4.8,0.6+3+0.2]);
-        translate([8.4,2.4,0]) rotate([0,tilt,0])cylinder(r=1,h=20,$fn=40);
-        translate([0,2.4,0]) rotate([0,tilt,0]) cylinder(r=1,h=20,$fn=40);
+        translate([8.6,2.4,0]) rotate([0,tilt,0])cylinder(r=1.3,h=20,$fn=40);
+        translate([-0.3,2.4,0]) rotate([0,tilt,0]) cylinder(r=1.3,h=20,$fn=40);
     }
 }
 //endstop_switch();

--- a/openscad/endstop.scad
+++ b/openscad/endstop.scad
@@ -1,0 +1,21 @@
+module endstop_switch(){
+    cube([8.6,4.8,3]);
+    //pads
+    translate([-1.3,1,0]) cube([8.6+2*1.3,2.25,0.3]);
+    //bottom connectors
+    translate([2.3,2.4,-0.6]) cylinder(r=0.55,h=1,$fn=50);
+    translate([6.3,2.4,-0.6]) cylinder(r=0.55,h=1,$fn=50);
+    //switch
+    translate([2.56,1.05,2.9]) cube([1,2.7,0.6]);
+}
+
+module endstop_hole(tilt){
+    translate([4.3,-2.4,-1])rotate([0,180,0]){
+        translate([-1.3,0,-3])cube([11.4,4.8,0.6+3+0.2]);
+        translate([8.4,2.4,0]) rotate([0,tilt,0])cylinder(r=1,h=20,$fn=40);
+        translate([0,2.4,0]) rotate([0,tilt,0]) cylinder(r=1,h=20,$fn=40);
+    }
+}
+//endstop_switch();
+endstop_hole(20);
+//translate([0,0,5]) endstop_switch();

--- a/openscad/feet.scad
+++ b/openscad/feet.scad
@@ -171,7 +171,7 @@ module foot(travel=5,       // how far into the foot the actuator can move down
         //TODO: check properly parametrized
         
         if(feet_endstops){           
-            translate([0,0.5-(h-travel)*sin(actuator_tilt),h-travel-endstop_hole_offset]) rotate([0,0,-90]) scale([1.1,1.1,1])endstop_hole(actuator_tilt);
+            translate([0,0.5-(h-travel)*sin(actuator_tilt),h-travel-endstop_hole_offset]) rotate([0,0,-90]) scale([1.03,1.08,1])endstop_hole(actuator_tilt);
           }
     } 
     
@@ -184,7 +184,7 @@ module middle_foot(lie_flat=false){
 }
 
 module outer_foot(lie_flat=false){
-    foot(travel=xy_actuator_travel,bottom_tilt=15, lie_flat=lie_flat);
+    foot(travel=xy_actuator_travel-avoid_objective_xyfoot_offset,bottom_tilt=15, lie_flat=lie_flat);
 }
 
 module feet_for_printing(lie_flat=true){
@@ -194,8 +194,6 @@ module feet_for_printing(lie_flat=true){
 //outer_foot(lie_flat=true);
 //foot(bottom_tilt=0, actuator_tilt=0, hover=2, lie_flat=true);
 feet_for_printing(lie_flat=true);
-echo(z_actuator_travel);
-echo(xy_actuator_travel);
 //middle_foot();
 //translate([20,0,0])rotate([90,0,0]) endstop_switch();
 //translate([0,30,0]) feet_for_printing(lie_flat=false);

--- a/openscad/feet.scad
+++ b/openscad/feet.scad
@@ -168,9 +168,10 @@ module foot(travel=5,       // how far into the foot the actuator can move down
         //cut off the foot below the "ground plane" (i.e. print bed)
         foot_ground_plane(tilt, top=0);
 
-         //TODO: check properly parametrized
+        //TODO: check properly parametrized
+        
         if(feet_endstops){           
-            translate([0,0.5-(h-travel)*sin(actuator_tilt),h-travel-1.5]) rotate([0,0,-90]) endstop_hole(actuator_tilt);
+            translate([0,0.5-(h-travel)*sin(actuator_tilt),h-travel-endstop_hole_offset]) rotate([0,0,-90]) scale([1.1,1.1,1])endstop_hole(actuator_tilt);
           }
     } 
     
@@ -179,11 +180,11 @@ module foot(travel=5,       // how far into the foot the actuator can move down
 //foot(tilt=0,hover=2);
 
 module middle_foot(lie_flat=false){
-        foot(bottom_tilt=0, actuator_tilt=z_actuator_tilt, hover=2, lie_flat=lie_flat);
+        foot(travel=z_actuator_travel,bottom_tilt=0, actuator_tilt=z_actuator_tilt, hover=2, lie_flat=lie_flat);
 }
 
 module outer_foot(lie_flat=false){
-    foot(bottom_tilt=15, lie_flat=lie_flat);
+    foot(travel=xy_actuator_travel,bottom_tilt=15, lie_flat=lie_flat);
 }
 
 module feet_for_printing(lie_flat=true){
@@ -193,6 +194,8 @@ module feet_for_printing(lie_flat=true){
 //outer_foot(lie_flat=true);
 //foot(bottom_tilt=0, actuator_tilt=0, hover=2, lie_flat=true);
 feet_for_printing(lie_flat=true);
+echo(z_actuator_travel);
+echo(xy_actuator_travel);
 //middle_foot();
 //translate([20,0,0])rotate([90,0,0]) endstop_switch();
 //translate([0,30,0]) feet_for_printing(lie_flat=false);

--- a/openscad/microscope_parameters.scad
+++ b/openscad/microscope_parameters.scad
@@ -116,5 +116,10 @@ base_mounting_holes = [[-20,z_nut_y-4,0],
                        [z_flexure_x+4,big_stage?-8:-4,0]]; 
                        // holes to screw the microscope to a baseplate
 
-endstop_extra_ringheight=feet_endstops?0:0;
+endstop_extra_ringheight=feet_endstops?1:0;
 endstop_hole_offset=0;
+//this is a temporary option to printfeet with smaller travel
+//without this with 15mm hole the stage hits the objective
+//the stage can move ~3mm in each direction, so the actuator only moves
+//~1.7 mm
+avoid_objective_xyfoot_offset=xy_actuator_travel-1.8;

--- a/openscad/microscope_parameters.scad
+++ b/openscad/microscope_parameters.scad
@@ -35,6 +35,8 @@ version_numstring = "5.19.0-b";
 camera = "picamera_2"; //see cameras/camera.scad for valid values
 optics = big_stage?"rms_f50d13":"pilens"; //see optics.scad for valid values
 led_r = 5/2; //size of the LED used for illumination
+feet_endstops=true;
+
 
 // This sets the basic geometry of the microscope
 sample_z = big_stage?65:40; // height of the top of the stage
@@ -47,7 +49,7 @@ z_strut_l = big_stage?18:15; //length of struts supporting Z carriage
 objective_mount_y = big_stage?15:9; // y position of clip for optics
 objective_mount_nose_w = 6; // width of the pointy end of the mount
 condenser_clip_w = 14; // width of the dovetail clip for the condenser
-foot_height = 15; //height of the feet (distance from bottom of body to table) tall feet are 26mm high
+foot_height=feet_endstops?17:15; //the endstops need a bit of extra height
 
 // These variables set the dimensions of flexures
 // You might want to tweak them if your material (or printer)
@@ -113,3 +115,5 @@ base_mounting_holes = [[-20,z_nut_y-4,0],
                        [-z_flexure_x-4,big_stage?-8:-4,0],
                        [z_flexure_x+4,big_stage?-8:-4,0]]; 
                        // holes to screw the microscope to a baseplate
+
+endstop_extra_ringheight=feet_endstops?1:0;

--- a/openscad/microscope_parameters.scad
+++ b/openscad/microscope_parameters.scad
@@ -49,7 +49,7 @@ z_strut_l = big_stage?18:15; //length of struts supporting Z carriage
 objective_mount_y = big_stage?15:9; // y position of clip for optics
 objective_mount_nose_w = 6; // width of the pointy end of the mount
 condenser_clip_w = 14; // width of the dovetail clip for the condenser
-foot_height=feet_endstops?17:15; //the endstops need a bit of extra height
+foot_height=feet_endstops?15:15; //the endstops need a bit of extra height (or not)
 
 // These variables set the dimensions of flexures
 // You might want to tweak them if your material (or printer)
@@ -116,4 +116,5 @@ base_mounting_holes = [[-20,z_nut_y-4,0],
                        [z_flexure_x+4,big_stage?-8:-4,0]]; 
                        // holes to screw the microscope to a baseplate
 
-endstop_extra_ringheight=feet_endstops?1:0;
+endstop_extra_ringheight=feet_endstops?0:0;
+endstop_hole_offset=0;


### PR DESCRIPTION
Adds holes to microscope feet to accommodate a D2LS-21 microswitch and wires. Can be disabled in microscope_parameters (feet_endstops).