### PR TITLE
Add option to print sample riser together with main body

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(OUTPUT)/lens_spacer_picamera_2_pilens_LS75.stl: $(SOURCE)/lens_spacer.scad $(o
 riser_dep_names := main_body
 riser_deps := $(optics_dep_names:%=$(SOURCE)/%.scad)
 $(OUTPUT)/sample_riser_LS10.stl: $(SOURCE)/sample_riser.scad $(riser_deps)
-	openscad -o $@ -D 'h=10' -D 'big_stage=true' $<
+	openscad -o $@ -D 'riser_h=10' -D 'big_stage=true' $<
 
 $(OUTPUT)/slide_riser_LS10.stl: $(SOURCE)/slide_riser.scad $(riser_deps)
 	openscad -o $@ -D 'h=10' -D 'big_stage=true' $<
@@ -146,5 +146,4 @@ $(OUTPUT)/actuator_assembly_tools.stl: $(SOURCE)/actuator_assembly_tools.scad $(
 
 $(OUTPUT)/%.stl: $(SOURCE)/%.scad $(all_deps)
 	openscad -o $@ $<
-
 

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ $(OUTPUT)/sample_riser_LS10.stl: $(SOURCE)/sample_riser.scad $(riser_deps)
 	openscad -o $@ -D 'riser_h=10' -D 'big_stage=true' $<
 
 $(OUTPUT)/slide_riser_LS10.stl: $(SOURCE)/slide_riser.scad $(riser_deps)
-	openscad -o $@ -D 'h=10' -D 'big_stage=true' $<
+	openscad -o $@ -D 'riser_h=10' -D 'big_stage=true' $<
 
 
 stand_dep_names := main_body
@@ -146,4 +146,5 @@ $(OUTPUT)/actuator_assembly_tools.stl: $(SOURCE)/actuator_assembly_tools.scad $(
 
 $(OUTPUT)/%.stl: $(SOURCE)/%.scad $(all_deps)
 	openscad -o $@ $<
+
 

--- a/builds/sample_riser_LS10.stl
+++ b/builds/sample_riser_LS10.stl
@@ -447,18 +447,18 @@ solid OpenSCAD_Model
       vertex -12.7303 19.8013 0
     endloop
   endfacet
-  facet normal -0.290285 -0.95694 0
+  facet normal -0.634394 -0.77301 0
     outer loop
-      vertex -12.3792 25.0976 3.5
-      vertex -11.7038 24.8927 10
-      vertex -12.3792 25.0976 10
+      vertex -11.0814 24.56 3.5
+      vertex -10.5359 24.1123 10
+      vertex -11.0814 24.56 10
     endloop
   endfacet
-  facet normal -0.290285 -0.95694 -0
+  facet normal -0.634394 -0.77301 -0
     outer loop
-      vertex -11.7038 24.8927 10
-      vertex -12.3792 25.0976 3.5
-      vertex -11.7038 24.8927 3.5
+      vertex -10.5359 24.1123 10
+      vertex -11.0814 24.56 3.5
+      vertex -10.5359 24.1123 3.5
     endloop
   endfacet
   facet normal 0.773009 0.634395 0
@@ -473,6 +473,118 @@ solid OpenSCAD_Model
       vertex -16.0748 19.5667 3.5
       vertex -15.6271 19.0212 10
       vertex -15.6271 19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex -16.0748 23.5668 10
+      vertex -15.6271 24.1123 3.5
+      vertex -15.6271 24.1123 10
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex -15.6271 24.1123 3.5
+      vertex -16.0748 23.5668 10
+      vertex -16.0748 23.5668 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex -10.5359 19.0212 3.5
+      vertex -10.0882 19.5667 10
+      vertex -10.0882 19.5667 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex -10.0882 19.5667 10
+      vertex -10.5359 19.0212 3.5
+      vertex -10.5359 19.0212 10
+    endloop
+  endfacet
+  facet normal 0.0980157 -0.995185 0
+    outer loop
+      vertex -13.7838 25.0976 3.5
+      vertex -13.0815 25.1668 10
+      vertex -13.7838 25.0976 10
+    endloop
+  endfacet
+  facet normal 0.0980157 -0.995185 0
+    outer loop
+      vertex -13.0815 25.1668 10
+      vertex -13.7838 25.0976 3.5
+      vertex -13.0815 25.1668 3.5
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980182 0
+    outer loop
+      vertex -16.6123 20.8644 10
+      vertex -16.6815 21.5668 3.5
+      vertex -16.6815 21.5668 10
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980182 0
+    outer loop
+      vertex -16.6815 21.5668 3.5
+      vertex -16.6123 20.8644 10
+      vertex -16.6123 20.8644 3.5
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290284 0
+    outer loop
+      vertex -16.6123 22.2691 10
+      vertex -16.4074 22.9444 3.5
+      vertex -16.4074 22.9444 10
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290284 0
+    outer loop
+      vertex -16.4074 22.9444 3.5
+      vertex -16.6123 22.2691 10
+      vertex -16.6123 22.2691 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290283 0
+    outer loop
+      vertex -9.55065 22.2691 3.5
+      vertex -9.75551 22.9444 10
+      vertex -9.75551 22.9444 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290283 0
+    outer loop
+      vertex -9.75551 22.9444 10
+      vertex -9.55065 22.2691 3.5
+      vertex -9.55065 22.2691 10
+    endloop
+  endfacet
+  facet normal -0.290285 -0.95694 0
+    outer loop
+      vertex -12.3792 25.0976 3.5
+      vertex -11.7038 24.8927 10
+      vertex -12.3792 25.0976 10
+    endloop
+  endfacet
+  facet normal -0.290285 -0.95694 -0
+    outer loop
+      vertex -11.7038 24.8927 10
+      vertex -12.3792 25.0976 3.5
+      vertex -11.7038 24.8927 3.5
+    endloop
+  endfacet
+  facet normal -0.471397 -0.881921 0
+    outer loop
+      vertex -11.7038 24.8927 3.5
+      vertex -11.0814 24.56 10
+      vertex -11.7038 24.8927 10
+    endloop
+  endfacet
+  facet normal -0.471397 -0.881921 -0
+    outer loop
+      vertex -11.0814 24.56 10
+      vertex -11.7038 24.8927 3.5
+      vertex -11.0814 24.56 3.5
     endloop
   endfacet
   facet normal -0.0980157 -0.995185 0
@@ -503,102 +615,18 @@ solid OpenSCAD_Model
       vertex -14.4591 24.8927 3.5
     endloop
   endfacet
-  facet normal 0.956941 -0.290284 0
+  facet normal 0.634394 -0.77301 0
     outer loop
-      vertex -16.6123 22.2691 10
-      vertex -16.4074 22.9444 3.5
-      vertex -16.4074 22.9444 10
-    endloop
-  endfacet
-  facet normal 0.956941 -0.290284 0
-    outer loop
-      vertex -16.4074 22.9444 3.5
-      vertex -16.6123 22.2691 10
-      vertex -16.6123 22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0.881922 0.471395 0
-    outer loop
-      vertex -16.0748 19.5667 10
-      vertex -16.4074 20.1891 3.5
-      vertex -16.4074 20.1891 10
-    endloop
-  endfacet
-  facet normal 0.881922 0.471395 0
-    outer loop
-      vertex -16.4074 20.1891 3.5
-      vertex -16.0748 19.5667 10
-      vertex -16.0748 19.5667 3.5
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex -10.0882 23.5668 3.5
-      vertex -10.5359 24.1123 10
-      vertex -10.5359 24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex -10.5359 24.1123 10
-      vertex -10.0882 23.5668 3.5
-      vertex -10.0882 23.5668 10
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex -10.0882 19.5667 3.5
-      vertex -9.75551 20.1891 10
-      vertex -9.75551 20.1891 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex -9.75551 20.1891 10
-      vertex -10.0882 19.5667 3.5
-      vertex -10.0882 19.5667 10
-    endloop
-  endfacet
-  facet normal -0.471397 -0.881921 0
-    outer loop
-      vertex -11.7038 24.8927 3.5
-      vertex -11.0814 24.56 10
-      vertex -11.7038 24.8927 10
-    endloop
-  endfacet
-  facet normal -0.471397 -0.881921 -0
-    outer loop
-      vertex -11.0814 24.56 10
-      vertex -11.7038 24.8927 3.5
-      vertex -11.0814 24.56 3.5
-    endloop
-  endfacet
-  facet normal 0.0980157 -0.995185 0
-    outer loop
-      vertex -13.7838 25.0976 3.5
-      vertex -13.0815 25.1668 10
-      vertex -13.7838 25.0976 10
-    endloop
-  endfacet
-  facet normal 0.0980157 -0.995185 0
-    outer loop
-      vertex -13.0815 25.1668 10
-      vertex -13.7838 25.0976 3.5
-      vertex -13.0815 25.1668 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex -16.0748 23.5668 10
       vertex -15.6271 24.1123 3.5
+      vertex -15.0815 24.56 10
       vertex -15.6271 24.1123 10
     endloop
   endfacet
-  facet normal 0.77301 -0.634394 0
+  facet normal 0.634394 -0.77301 0
     outer loop
+      vertex -15.0815 24.56 10
       vertex -15.6271 24.1123 3.5
-      vertex -16.0748 23.5668 10
-      vertex -16.0748 23.5668 3.5
+      vertex -15.0815 24.56 3.5
     endloop
   endfacet
   facet normal 0.290284 -0.95694 0
@@ -629,6 +657,20 @@ solid OpenSCAD_Model
       vertex -16.4074 20.1891 3.5
     endloop
   endfacet
+  facet normal 0.881922 0.471395 0
+    outer loop
+      vertex -16.0748 19.5667 10
+      vertex -16.4074 20.1891 3.5
+      vertex -16.4074 20.1891 10
+    endloop
+  endfacet
+  facet normal 0.881922 0.471395 0
+    outer loop
+      vertex -16.4074 20.1891 3.5
+      vertex -16.0748 19.5667 10
+      vertex -16.0748 19.5667 3.5
+    endloop
+  endfacet
   facet normal 0.995185 -0.0980185 0
     outer loop
       vertex -16.6815 21.5668 10
@@ -657,32 +699,452 @@ solid OpenSCAD_Model
       vertex -16.4074 22.9444 3.5
     endloop
   endfacet
-  facet normal 0.995185 0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.6123 20.8644 10
-      vertex -16.6815 21.5668 3.5
-      vertex -16.6815 21.5668 10
+      vertex -11.2815 21.5668 3.5
+      vertex -9.48148 21.5668 3.5
+      vertex -9.55065 22.2691 3.5
     endloop
   endfacet
-  facet normal 0.995185 0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.6815 21.5668 3.5
-      vertex -16.6123 20.8644 10
-      vertex -16.6123 20.8644 3.5
+      vertex -11.3161 21.9179 3.5
+      vertex -9.55065 22.2691 3.5
+      vertex -9.75551 22.9444 3.5
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 0
+  facet normal 0 0 1
     outer loop
-      vertex -11.0814 24.56 3.5
-      vertex -10.5359 24.1123 10
-      vertex -11.0814 24.56 10
+      vertex -9.48148 21.5668 3.5
+      vertex -11.2815 21.5668 3.5
+      vertex -9.55065 20.8644 3.5
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 -0
+  facet normal 0 0 1
     outer loop
-      vertex -10.5359 24.1123 10
-      vertex -11.0814 24.56 3.5
+      vertex -11.4185 22.2556 3.5
+      vertex -9.75551 22.9444 3.5
+      vertex -10.0882 23.5668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.3161 21.2156 3.5
+      vertex -9.55065 20.8644 3.5
+      vertex -11.2815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5848 22.5668 3.5
+      vertex -10.0882 23.5668 3.5
       vertex -10.5359 24.1123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55065 20.8644 3.5
+      vertex -11.3161 21.2156 3.5
+      vertex -9.75551 20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.8087 22.8395 3.5
+      vertex -10.5359 24.1123 3.5
+      vertex -11.0814 24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.4185 20.8779 3.5
+      vertex -9.75551 20.1891 3.5
+      vertex -11.3161 21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 20.1891 3.5
+      vertex -11.4185 20.8779 3.5
+      vertex -10.0882 19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55065 22.2691 3.5
+      vertex -11.3161 21.9179 3.5
+      vertex -11.2815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 22.9444 3.5
+      vertex -11.4185 22.2556 3.5
+      vertex -11.3161 21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.0882 23.5668 3.5
+      vertex -11.5848 22.5668 3.5
+      vertex -11.4185 22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0814 23.0634 3.5
+      vertex -11.0814 24.56 3.5
+      vertex -11.7038 24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 24.1123 3.5
+      vertex -11.8087 22.8395 3.5
+      vertex -11.5848 22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 24.56 3.5
+      vertex -12.0814 23.0634 3.5
+      vertex -11.8087 22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3926 23.2297 3.5
+      vertex -11.7038 24.8927 3.5
+      vertex -12.3792 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 24.8927 3.5
+      vertex -12.3926 23.2297 3.5
+      vertex -12.0814 23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 25.0976 3.5
+      vertex -12.7303 23.3322 3.5
+      vertex -12.3926 23.2297 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 25.1668 3.5
+      vertex -12.7303 23.3322 3.5
+      vertex -12.3792 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 25.1668 3.5
+      vertex -13.0815 23.3668 3.5
+      vertex -12.7303 23.3322 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 25.1668 3.5
+      vertex -13.4326 23.3322 3.5
+      vertex -13.0815 23.3668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.7838 25.0976 3.5
+      vertex -13.4326 23.3322 3.5
+      vertex -13.0815 25.1668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 23.3322 3.5
+      vertex -13.7838 25.0976 3.5
+      vertex -13.7703 23.2297 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.4591 24.8927 3.5
+      vertex -13.7703 23.2297 3.5
+      vertex -13.7838 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7703 23.2297 3.5
+      vertex -14.4591 24.8927 3.5
+      vertex -14.0815 23.0634 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.0815 24.56 3.5
+      vertex -14.0815 23.0634 3.5
+      vertex -14.4591 24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0815 23.0634 3.5
+      vertex -15.0815 24.56 3.5
+      vertex -14.3543 22.8395 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6271 24.1123 3.5
+      vertex -14.3543 22.8395 3.5
+      vertex -15.0815 24.56 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3543 22.8395 3.5
+      vertex -15.6271 24.1123 3.5
+      vertex -14.5781 22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5781 22.5668 3.5
+      vertex -16.0748 23.5668 3.5
+      vertex -14.7445 22.2556 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.0748 23.5668 3.5
+      vertex -14.5781 22.5668 3.5
+      vertex -15.6271 24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.5848 20.5667 3.5
+      vertex -10.0882 19.5667 3.5
+      vertex -11.4185 20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.0882 19.5667 3.5
+      vertex -11.5848 20.5667 3.5
+      vertex -10.5359 19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.8087 20.294 3.5
+      vertex -10.5359 19.0212 3.5
+      vertex -11.5848 20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 19.0212 3.5
+      vertex -11.8087 20.294 3.5
+      vertex -11.0814 18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.0814 20.0701 3.5
+      vertex -11.0814 18.5735 3.5
+      vertex -11.8087 20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 18.5735 3.5
+      vertex -12.0814 20.0701 3.5
+      vertex -11.7038 18.2408 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3926 19.9038 3.5
+      vertex -11.7038 18.2408 3.5
+      vertex -12.0814 20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 18.2408 3.5
+      vertex -12.3926 19.9038 3.5
+      vertex -12.3792 18.0359 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.7303 19.8013 3.5
+      vertex -12.3792 18.0359 3.5
+      vertex -12.3926 19.9038 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0815 19.7668 3.5
+      vertex -12.3792 18.0359 3.5
+      vertex -12.7303 19.8013 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 19.7668 3.5
+      vertex -13.0815 17.9668 3.5
+      vertex -12.3792 18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 19.8013 3.5
+      vertex -13.0815 17.9668 3.5
+      vertex -13.0815 19.7668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 18.0359 3.5
+      vertex -13.4326 19.8013 3.5
+      vertex -13.7703 19.9038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 19.8013 3.5
+      vertex -13.7838 18.0359 3.5
+      vertex -13.0815 17.9668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 18.2408 3.5
+      vertex -13.7703 19.9038 3.5
+      vertex -14.0815 20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 18.5735 3.5
+      vertex -14.0815 20.0701 3.5
+      vertex -14.3543 20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7703 19.9038 3.5
+      vertex -14.4591 18.2408 3.5
+      vertex -13.7838 18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6271 19.0212 3.5
+      vertex -14.3543 20.294 3.5
+      vertex -14.5781 20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 19.5667 3.5
+      vertex -14.5781 20.5667 3.5
+      vertex -14.7445 20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4074 20.1891 3.5
+      vertex -14.7445 20.8779 3.5
+      vertex -14.8469 21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0815 20.0701 3.5
+      vertex -15.0815 18.5735 3.5
+      vertex -14.4591 18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 20.8644 3.5
+      vertex -14.8469 21.2156 3.5
+      vertex -14.8815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.4074 22.9444 3.5
+      vertex -14.7445 22.2556 3.5
+      vertex -16.0748 23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7445 22.2556 3.5
+      vertex -16.4074 22.9444 3.5
+      vertex -14.8469 21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3543 20.294 3.5
+      vertex -15.6271 19.0212 3.5
+      vertex -15.0815 18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.6123 22.2691 3.5
+      vertex -14.8469 21.9179 3.5
+      vertex -16.4074 22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5781 20.5667 3.5
+      vertex -16.0748 19.5667 3.5
+      vertex -15.6271 19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8469 21.9179 3.5
+      vertex -16.6123 22.2691 3.5
+      vertex -14.8815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7445 20.8779 3.5
+      vertex -16.4074 20.1891 3.5
+      vertex -16.0748 19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6815 21.5668 3.5
+      vertex -14.8815 21.5668 3.5
+      vertex -16.6123 22.2691 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8469 21.2156 3.5
+      vertex -16.6123 20.8644 3.5
+      vertex -16.4074 20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8815 21.5668 3.5
+      vertex -16.6815 21.5668 3.5
+      vertex -16.6123 20.8644 3.5
     endloop
   endfacet
   facet normal -0.881921 -0.471398 0
@@ -699,60 +1161,18 @@ solid OpenSCAD_Model
       vertex -9.75551 22.9444 10
     endloop
   endfacet
-  facet normal -0.995185 0.0980169 0
+  facet normal -0.773011 -0.634393 0
     outer loop
-      vertex -9.55065 20.8644 3.5
-      vertex -9.48148 21.5668 10
-      vertex -9.48148 21.5668 3.5
+      vertex -10.0882 23.5668 3.5
+      vertex -10.5359 24.1123 10
+      vertex -10.5359 24.1123 3.5
     endloop
   endfacet
-  facet normal -0.995185 0.0980169 0
+  facet normal -0.773011 -0.634393 0
     outer loop
-      vertex -9.48148 21.5668 10
-      vertex -9.55065 20.8644 3.5
-      vertex -9.55065 20.8644 10
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex -15.6271 24.1123 3.5
-      vertex -15.0815 24.56 10
-      vertex -15.6271 24.1123 10
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex -15.0815 24.56 10
-      vertex -15.6271 24.1123 3.5
-      vertex -15.0815 24.56 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 -0.290283 0
-    outer loop
-      vertex -9.55065 22.2691 3.5
-      vertex -9.75551 22.9444 10
-      vertex -9.75551 22.9444 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 -0.290283 0
-    outer loop
-      vertex -9.75551 22.9444 10
-      vertex -9.55065 22.2691 3.5
-      vertex -9.55065 22.2691 10
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 -0
-    outer loop
-      vertex -15.0815 18.5735 3.5
-      vertex -15.6271 19.0212 10
-      vertex -15.0815 18.5735 10
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 0
-    outer loop
-      vertex -15.6271 19.0212 10
-      vertex -15.0815 18.5735 3.5
-      vertex -15.6271 19.0212 3.5
+      vertex -10.5359 24.1123 10
+      vertex -10.0882 23.5668 3.5
+      vertex -10.0882 23.5668 10
     endloop
   endfacet
   facet normal 0.290284 0.95694 -0
@@ -769,494 +1189,18 @@ solid OpenSCAD_Model
       vertex -14.4591 18.2408 3.5
     endloop
   endfacet
-  facet normal -0.956941 0.290284 0
+  facet normal -0.995185 0.0980169 0
     outer loop
-      vertex -9.75551 20.1891 3.5
-      vertex -9.55065 20.8644 10
       vertex -9.55065 20.8644 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 0.290284 0
-    outer loop
-      vertex -9.55065 20.8644 10
-      vertex -9.75551 20.1891 3.5
-      vertex -9.75551 20.1891 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex -10.5359 19.0212 3.5
-      vertex -11.0814 18.5735 10
-      vertex -10.5359 19.0212 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex -11.0814 18.5735 10
-      vertex -10.5359 19.0212 3.5
-      vertex -11.0814 18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex -10.5359 19.0212 3.5
-      vertex -10.0882 19.5667 10
-      vertex -10.0882 19.5667 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex -10.0882 19.5667 10
-      vertex -10.5359 19.0212 3.5
-      vertex -10.5359 19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.2815 21.5668 3.5
+      vertex -9.48148 21.5668 10
       vertex -9.48148 21.5668 3.5
-      vertex -9.55065 22.2691 3.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995185 0.0980169 0
     outer loop
-      vertex -11.3161 21.9179 3.5
-      vertex -9.55065 22.2691 3.5
-      vertex -9.75551 22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.48148 21.5668 3.5
-      vertex -11.2815 21.5668 3.5
+      vertex -9.48148 21.5668 10
       vertex -9.55065 20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.4185 22.2556 3.5
-      vertex -9.75551 22.9444 3.5
-      vertex -10.0882 23.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.3161 21.2156 3.5
-      vertex -9.55065 20.8644 3.5
-      vertex -11.2815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5848 22.5668 3.5
-      vertex -10.0882 23.5668 3.5
-      vertex -10.5359 24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.55065 20.8644 3.5
-      vertex -11.3161 21.2156 3.5
-      vertex -9.75551 20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.8087 22.8395 3.5
-      vertex -10.5359 24.1123 3.5
-      vertex -11.0814 24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.4185 20.8779 3.5
-      vertex -9.75551 20.1891 3.5
-      vertex -11.3161 21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.75551 20.1891 3.5
-      vertex -11.4185 20.8779 3.5
-      vertex -10.0882 19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.55065 22.2691 3.5
-      vertex -11.3161 21.9179 3.5
-      vertex -11.2815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.75551 22.9444 3.5
-      vertex -11.4185 22.2556 3.5
-      vertex -11.3161 21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.0882 23.5668 3.5
-      vertex -11.5848 22.5668 3.5
-      vertex -11.4185 22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0814 23.0634 3.5
-      vertex -11.0814 24.56 3.5
-      vertex -11.7038 24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 24.1123 3.5
-      vertex -11.8087 22.8395 3.5
-      vertex -11.5848 22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 24.56 3.5
-      vertex -12.0814 23.0634 3.5
-      vertex -11.8087 22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3926 23.2297 3.5
-      vertex -11.7038 24.8927 3.5
-      vertex -12.3792 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 24.8927 3.5
-      vertex -12.3926 23.2297 3.5
-      vertex -12.0814 23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 25.0976 3.5
-      vertex -12.7303 23.3322 3.5
-      vertex -12.3926 23.2297 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 25.1668 3.5
-      vertex -12.7303 23.3322 3.5
-      vertex -12.3792 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 25.1668 3.5
-      vertex -13.0815 23.3668 3.5
-      vertex -12.7303 23.3322 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 25.1668 3.5
-      vertex -13.4326 23.3322 3.5
-      vertex -13.0815 23.3668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.7838 25.0976 3.5
-      vertex -13.4326 23.3322 3.5
-      vertex -13.0815 25.1668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 23.3322 3.5
-      vertex -13.7838 25.0976 3.5
-      vertex -13.7703 23.2297 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.4591 24.8927 3.5
-      vertex -13.7703 23.2297 3.5
-      vertex -13.7838 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7703 23.2297 3.5
-      vertex -14.4591 24.8927 3.5
-      vertex -14.0815 23.0634 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.0815 24.56 3.5
-      vertex -14.0815 23.0634 3.5
-      vertex -14.4591 24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0815 23.0634 3.5
-      vertex -15.0815 24.56 3.5
-      vertex -14.3543 22.8395 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.6271 24.1123 3.5
-      vertex -14.3543 22.8395 3.5
-      vertex -15.0815 24.56 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3543 22.8395 3.5
-      vertex -15.6271 24.1123 3.5
-      vertex -14.5781 22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5781 22.5668 3.5
-      vertex -16.0748 23.5668 3.5
-      vertex -14.7445 22.2556 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.0748 23.5668 3.5
-      vertex -14.5781 22.5668 3.5
-      vertex -15.6271 24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.5848 20.5667 3.5
-      vertex -10.0882 19.5667 3.5
-      vertex -11.4185 20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.0882 19.5667 3.5
-      vertex -11.5848 20.5667 3.5
-      vertex -10.5359 19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.8087 20.294 3.5
-      vertex -10.5359 19.0212 3.5
-      vertex -11.5848 20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 19.0212 3.5
-      vertex -11.8087 20.294 3.5
-      vertex -11.0814 18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.0814 20.0701 3.5
-      vertex -11.0814 18.5735 3.5
-      vertex -11.8087 20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 18.5735 3.5
-      vertex -12.0814 20.0701 3.5
-      vertex -11.7038 18.2408 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.3926 19.9038 3.5
-      vertex -11.7038 18.2408 3.5
-      vertex -12.0814 20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 18.2408 3.5
-      vertex -12.3926 19.9038 3.5
-      vertex -12.3792 18.0359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.7303 19.8013 3.5
-      vertex -12.3792 18.0359 3.5
-      vertex -12.3926 19.9038 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.0815 19.7668 3.5
-      vertex -12.3792 18.0359 3.5
-      vertex -12.7303 19.8013 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 19.7668 3.5
-      vertex -13.0815 17.9668 3.5
-      vertex -12.3792 18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 19.8013 3.5
-      vertex -13.0815 17.9668 3.5
-      vertex -13.0815 19.7668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7838 18.0359 3.5
-      vertex -13.4326 19.8013 3.5
-      vertex -13.7703 19.9038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 19.8013 3.5
-      vertex -13.7838 18.0359 3.5
-      vertex -13.0815 17.9668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4591 18.2408 3.5
-      vertex -13.7703 19.9038 3.5
-      vertex -14.0815 20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0815 18.5735 3.5
-      vertex -14.0815 20.0701 3.5
-      vertex -14.3543 20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7703 19.9038 3.5
-      vertex -14.4591 18.2408 3.5
-      vertex -13.7838 18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6271 19.0212 3.5
-      vertex -14.3543 20.294 3.5
-      vertex -14.5781 20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 19.5667 3.5
-      vertex -14.5781 20.5667 3.5
-      vertex -14.7445 20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 20.1891 3.5
-      vertex -14.7445 20.8779 3.5
-      vertex -14.8469 21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0815 20.0701 3.5
-      vertex -15.0815 18.5735 3.5
-      vertex -14.4591 18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 20.8644 3.5
-      vertex -14.8469 21.2156 3.5
-      vertex -14.8815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.4074 22.9444 3.5
-      vertex -14.7445 22.2556 3.5
-      vertex -16.0748 23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7445 22.2556 3.5
-      vertex -16.4074 22.9444 3.5
-      vertex -14.8469 21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3543 20.294 3.5
-      vertex -15.6271 19.0212 3.5
-      vertex -15.0815 18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.6123 22.2691 3.5
-      vertex -14.8469 21.9179 3.5
-      vertex -16.4074 22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5781 20.5667 3.5
-      vertex -16.0748 19.5667 3.5
-      vertex -15.6271 19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8469 21.9179 3.5
-      vertex -16.6123 22.2691 3.5
-      vertex -14.8815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7445 20.8779 3.5
-      vertex -16.4074 20.1891 3.5
-      vertex -16.0748 19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6815 21.5668 3.5
-      vertex -14.8815 21.5668 3.5
-      vertex -16.6123 22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8469 21.2156 3.5
-      vertex -16.6123 20.8644 3.5
-      vertex -16.4074 20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8815 21.5668 3.5
-      vertex -16.6815 21.5668 3.5
-      vertex -16.6123 20.8644 3.5
+      vertex -9.55065 20.8644 10
     endloop
   endfacet
   facet normal 0.471397 0.881921 -0
@@ -1271,6 +1215,48 @@ solid OpenSCAD_Model
       vertex -15.0815 18.5735 10
       vertex -14.4591 18.2408 3.5
       vertex -15.0815 18.5735 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 -0
+    outer loop
+      vertex -15.0815 18.5735 3.5
+      vertex -15.6271 19.0212 10
+      vertex -15.0815 18.5735 10
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 0
+    outer loop
+      vertex -15.6271 19.0212 10
+      vertex -15.0815 18.5735 3.5
+      vertex -15.6271 19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex -9.75551 20.1891 3.5
+      vertex -9.55065 20.8644 10
+      vertex -9.55065 20.8644 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex -9.55065 20.8644 10
+      vertex -9.75551 20.1891 3.5
+      vertex -9.75551 20.1891 10
+    endloop
+  endfacet
+  facet normal -0.881921 0.471397 0
+    outer loop
+      vertex -10.0882 19.5667 3.5
+      vertex -9.75551 20.1891 10
+      vertex -9.75551 20.1891 3.5
+    endloop
+  endfacet
+  facet normal -0.881921 0.471397 0
+    outer loop
+      vertex -9.75551 20.1891 10
+      vertex -10.0882 19.5667 3.5
+      vertex -10.0882 19.5667 10
     endloop
   endfacet
   facet normal -0.995185 -0.0980171 0
@@ -1313,6 +1299,20 @@ solid OpenSCAD_Model
       vertex -11.7038 18.2408 10
       vertex -11.0814 18.5735 3.5
       vertex -11.7038 18.2408 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex -10.5359 19.0212 3.5
+      vertex -11.0814 18.5735 10
+      vertex -10.5359 19.0212 10
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex -11.0814 18.5735 10
+      vertex -10.5359 19.0212 3.5
+      vertex -11.0814 18.5735 3.5
     endloop
   endfacet
   facet normal 0.0980157 0.995185 -0
@@ -1791,18 +1791,18 @@ solid OpenSCAD_Model
       vertex -19.9038 12.3926 3.5
     endloop
   endfacet
-  facet normal 0.95694 0.290285 0
+  facet normal 0.77301 0.634394 0
     outer loop
-      vertex -24.8927 11.7038 10
-      vertex -25.0976 12.3792 3.5
-      vertex -25.0976 12.3792 10
+      vertex -24.1123 10.5359 10
+      vertex -24.56 11.0814 3.5
+      vertex -24.56 11.0814 10
     endloop
   endfacet
-  facet normal 0.95694 0.290285 0
+  facet normal 0.77301 0.634394 0
     outer loop
-      vertex -25.0976 12.3792 3.5
-      vertex -24.8927 11.7038 10
-      vertex -24.8927 11.7038 3.5
+      vertex -24.56 11.0814 3.5
+      vertex -24.1123 10.5359 10
+      vertex -24.1123 10.5359 3.5
     endloop
   endfacet
   facet normal -0.634395 -0.773009 0
@@ -1817,6 +1817,118 @@ solid OpenSCAD_Model
       vertex -19.0212 15.6271 10
       vertex -19.5667 16.0748 3.5
       vertex -19.0212 15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex -24.1123 15.6271 3.5
+      vertex -23.5668 16.0748 10
+      vertex -24.1123 15.6271 10
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex -23.5668 16.0748 10
+      vertex -24.1123 15.6271 3.5
+      vertex -23.5668 16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex -19.0212 10.5359 3.5
+      vertex -19.5667 10.0882 10
+      vertex -19.0212 10.5359 10
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex -19.5667 10.0882 10
+      vertex -19.0212 10.5359 3.5
+      vertex -19.5667 10.0882 3.5
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980157 0
+    outer loop
+      vertex -25.1668 13.0815 10
+      vertex -25.0976 13.7838 3.5
+      vertex -25.0976 13.7838 10
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980157 0
+    outer loop
+      vertex -25.0976 13.7838 3.5
+      vertex -25.1668 13.0815 10
+      vertex -25.1668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0.0980182 -0.995185 0
+    outer loop
+      vertex -21.5668 16.6815 3.5
+      vertex -20.8644 16.6123 10
+      vertex -21.5668 16.6815 10
+    endloop
+  endfacet
+  facet normal -0.0980182 -0.995185 -0
+    outer loop
+      vertex -20.8644 16.6123 10
+      vertex -21.5668 16.6815 3.5
+      vertex -20.8644 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0.290284 -0.956941 0
+    outer loop
+      vertex -22.9444 16.4074 3.5
+      vertex -22.2691 16.6123 10
+      vertex -22.9444 16.4074 10
+    endloop
+  endfacet
+  facet normal 0.290284 -0.956941 0
+    outer loop
+      vertex -22.2691 16.6123 10
+      vertex -22.9444 16.4074 3.5
+      vertex -22.2691 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0.290283 0.956941 -0
+    outer loop
+      vertex -22.2691 9.55065 3.5
+      vertex -22.9444 9.75551 10
+      vertex -22.2691 9.55065 10
+    endloop
+  endfacet
+  facet normal 0.290283 0.956941 0
+    outer loop
+      vertex -22.9444 9.75551 10
+      vertex -22.2691 9.55065 3.5
+      vertex -22.9444 9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0.95694 0.290285 0
+    outer loop
+      vertex -24.8927 11.7038 10
+      vertex -25.0976 12.3792 3.5
+      vertex -25.0976 12.3792 10
+    endloop
+  endfacet
+  facet normal 0.95694 0.290285 0
+    outer loop
+      vertex -25.0976 12.3792 3.5
+      vertex -24.8927 11.7038 10
+      vertex -24.8927 11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0.881921 0.471397 0
+    outer loop
+      vertex -24.56 11.0814 10
+      vertex -24.8927 11.7038 3.5
+      vertex -24.8927 11.7038 10
+    endloop
+  endfacet
+  facet normal 0.881921 0.471397 0
+    outer loop
+      vertex -24.8927 11.7038 3.5
+      vertex -24.56 11.0814 10
+      vertex -24.56 11.0814 3.5
     endloop
   endfacet
   facet normal 0.995185 0.0980157 0
@@ -1847,102 +1959,18 @@ solid OpenSCAD_Model
       vertex -24.8927 14.4591 3.5
     endloop
   endfacet
-  facet normal 0.290284 -0.956941 0
+  facet normal 0.77301 -0.634394 0
     outer loop
-      vertex -22.9444 16.4074 3.5
-      vertex -22.2691 16.6123 10
-      vertex -22.9444 16.4074 10
-    endloop
-  endfacet
-  facet normal 0.290284 -0.956941 0
-    outer loop
-      vertex -22.2691 16.6123 10
-      vertex -22.9444 16.4074 3.5
-      vertex -22.2691 16.6123 3.5
-    endloop
-  endfacet
-  facet normal -0.471395 -0.881922 0
-    outer loop
-      vertex -20.1891 16.4074 3.5
-      vertex -19.5667 16.0748 10
-      vertex -20.1891 16.4074 10
-    endloop
-  endfacet
-  facet normal -0.471395 -0.881922 -0
-    outer loop
-      vertex -19.5667 16.0748 10
-      vertex -20.1891 16.4074 3.5
-      vertex -19.5667 16.0748 3.5
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 -0
-    outer loop
-      vertex -23.5668 10.0882 3.5
-      vertex -24.1123 10.5359 10
-      vertex -23.5668 10.0882 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 0
-    outer loop
-      vertex -24.1123 10.5359 10
-      vertex -23.5668 10.0882 3.5
-      vertex -24.1123 10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex -19.5667 10.0882 3.5
-      vertex -20.1891 9.75551 10
-      vertex -19.5667 10.0882 10
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex -20.1891 9.75551 10
-      vertex -19.5667 10.0882 3.5
-      vertex -20.1891 9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0.881921 0.471397 0
-    outer loop
-      vertex -24.56 11.0814 10
-      vertex -24.8927 11.7038 3.5
-      vertex -24.8927 11.7038 10
-    endloop
-  endfacet
-  facet normal 0.881921 0.471397 0
-    outer loop
-      vertex -24.8927 11.7038 3.5
-      vertex -24.56 11.0814 10
-      vertex -24.56 11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0.995185 -0.0980157 0
-    outer loop
-      vertex -25.1668 13.0815 10
-      vertex -25.0976 13.7838 3.5
-      vertex -25.0976 13.7838 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.0980157 0
-    outer loop
-      vertex -25.0976 13.7838 3.5
-      vertex -25.1668 13.0815 10
-      vertex -25.1668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
+      vertex -24.56 15.0815 10
       vertex -24.1123 15.6271 3.5
-      vertex -23.5668 16.0748 10
       vertex -24.1123 15.6271 10
     endloop
   endfacet
-  facet normal 0.634394 -0.77301 0
+  facet normal 0.77301 -0.634394 0
     outer loop
-      vertex -23.5668 16.0748 10
       vertex -24.1123 15.6271 3.5
-      vertex -23.5668 16.0748 3.5
+      vertex -24.56 15.0815 10
+      vertex -24.56 15.0815 3.5
     endloop
   endfacet
   facet normal 0.95694 -0.290284 0
@@ -1973,6 +2001,20 @@ solid OpenSCAD_Model
       vertex -20.1891 16.4074 3.5
     endloop
   endfacet
+  facet normal -0.471395 -0.881922 0
+    outer loop
+      vertex -20.1891 16.4074 3.5
+      vertex -19.5667 16.0748 10
+      vertex -20.1891 16.4074 10
+    endloop
+  endfacet
+  facet normal -0.471395 -0.881922 -0
+    outer loop
+      vertex -19.5667 16.0748 10
+      vertex -20.1891 16.4074 3.5
+      vertex -19.5667 16.0748 3.5
+    endloop
+  endfacet
   facet normal 0.0980185 -0.995185 0
     outer loop
       vertex -22.2691 16.6123 3.5
@@ -2001,32 +2043,452 @@ solid OpenSCAD_Model
       vertex -22.9444 16.4074 3.5
     endloop
   endfacet
-  facet normal -0.0980182 -0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex -21.5668 16.6815 3.5
-      vertex -20.8644 16.6123 10
-      vertex -21.5668 16.6815 10
+      vertex -19.7668 13.0815 3.5
+      vertex -17.9668 13.0815 3.5
+      vertex -18.0359 13.7838 3.5
     endloop
   endfacet
-  facet normal -0.0980182 -0.995185 -0
+  facet normal 0 0 1
     outer loop
-      vertex -20.8644 16.6123 10
-      vertex -21.5668 16.6815 3.5
+      vertex -19.8013 13.4326 3.5
+      vertex -18.0359 13.7838 3.5
+      vertex -18.2408 14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 13.0815 3.5
+      vertex -19.7668 13.0815 3.5
+      vertex -18.0359 12.3792 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.9038 13.7703 3.5
+      vertex -18.2408 14.4591 3.5
+      vertex -18.5735 15.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.8013 12.7303 3.5
+      vertex -18.0359 12.3792 3.5
+      vertex -19.7668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.0701 14.0815 3.5
+      vertex -18.5735 15.0815 3.5
+      vertex -19.0212 15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0359 12.3792 3.5
+      vertex -19.8013 12.7303 3.5
+      vertex -18.2408 11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.294 14.3543 3.5
+      vertex -19.0212 15.6271 3.5
+      vertex -19.5667 16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.9038 12.3926 3.5
+      vertex -18.2408 11.7038 3.5
+      vertex -19.8013 12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2408 11.7038 3.5
+      vertex -19.9038 12.3926 3.5
+      vertex -18.5735 11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0359 13.7838 3.5
+      vertex -19.8013 13.4326 3.5
+      vertex -19.7668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2408 14.4591 3.5
+      vertex -19.9038 13.7703 3.5
+      vertex -19.8013 13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 15.0815 3.5
+      vertex -20.0701 14.0815 3.5
+      vertex -19.9038 13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5667 14.5781 3.5
+      vertex -19.5667 16.0748 3.5
+      vertex -20.1891 16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 15.6271 3.5
+      vertex -20.294 14.3543 3.5
+      vertex -20.0701 14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 16.0748 3.5
+      vertex -20.5667 14.5781 3.5
+      vertex -20.294 14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8779 14.7445 3.5
+      vertex -20.1891 16.4074 3.5
       vertex -20.8644 16.6123 3.5
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex -24.1123 10.5359 10
-      vertex -24.56 11.0814 3.5
-      vertex -24.56 11.0814 10
+      vertex -20.1891 16.4074 3.5
+      vertex -20.8779 14.7445 3.5
+      vertex -20.5667 14.5781 3.5
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8644 16.6123 3.5
+      vertex -21.2156 14.8469 3.5
+      vertex -20.8779 14.7445 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 16.6815 3.5
+      vertex -21.2156 14.8469 3.5
+      vertex -20.8644 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 16.6815 3.5
+      vertex -21.5668 14.8815 3.5
+      vertex -21.2156 14.8469 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 16.6815 3.5
+      vertex -21.9179 14.8469 3.5
+      vertex -21.5668 14.8815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.2691 16.6123 3.5
+      vertex -21.9179 14.8469 3.5
+      vertex -21.5668 16.6815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 14.8469 3.5
+      vertex -22.2691 16.6123 3.5
+      vertex -22.2556 14.7445 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.9444 16.4074 3.5
+      vertex -22.2556 14.7445 3.5
+      vertex -22.2691 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2556 14.7445 3.5
+      vertex -22.9444 16.4074 3.5
+      vertex -22.5668 14.5781 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.5668 16.0748 3.5
+      vertex -22.5668 14.5781 3.5
+      vertex -22.9444 16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5668 14.5781 3.5
+      vertex -23.5668 16.0748 3.5
+      vertex -22.8395 14.3543 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.1123 15.6271 3.5
+      vertex -22.8395 14.3543 3.5
+      vertex -23.5668 16.0748 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.8395 14.3543 3.5
+      vertex -24.1123 15.6271 3.5
+      vertex -23.0634 14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0634 14.0815 3.5
+      vertex -24.56 15.0815 3.5
+      vertex -23.2297 13.7703 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.56 15.0815 3.5
+      vertex -23.0634 14.0815 3.5
+      vertex -24.1123 15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.0701 12.0814 3.5
+      vertex -18.5735 11.0814 3.5
+      vertex -19.9038 12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 11.0814 3.5
+      vertex -20.0701 12.0814 3.5
+      vertex -19.0212 10.5359 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.294 11.8087 3.5
+      vertex -19.0212 10.5359 3.5
+      vertex -20.0701 12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 10.5359 3.5
+      vertex -20.294 11.8087 3.5
+      vertex -19.5667 10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.5667 11.5848 3.5
+      vertex -19.5667 10.0882 3.5
+      vertex -20.294 11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 10.0882 3.5
+      vertex -20.5667 11.5848 3.5
+      vertex -20.1891 9.75551 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8779 11.4185 3.5
+      vertex -20.1891 9.75551 3.5
+      vertex -20.5667 11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1891 9.75551 3.5
+      vertex -20.8779 11.4185 3.5
+      vertex -20.8644 9.55065 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.2156 11.3161 3.5
+      vertex -20.8644 9.55065 3.5
+      vertex -20.8779 11.4185 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5668 11.2815 3.5
+      vertex -20.8644 9.55065 3.5
+      vertex -21.2156 11.3161 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 11.2815 3.5
+      vertex -21.5668 9.48148 3.5
+      vertex -20.8644 9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 11.3161 3.5
+      vertex -21.5668 9.48148 3.5
+      vertex -21.5668 11.2815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 9.55065 3.5
+      vertex -21.9179 11.3161 3.5
+      vertex -22.2556 11.4185 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 11.3161 3.5
+      vertex -22.2691 9.55065 3.5
+      vertex -21.5668 9.48148 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9444 9.75551 3.5
+      vertex -22.2556 11.4185 3.5
+      vertex -22.5668 11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 10.0882 3.5
+      vertex -22.5668 11.5848 3.5
+      vertex -22.8395 11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2556 11.4185 3.5
+      vertex -22.9444 9.75551 3.5
+      vertex -22.2691 9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1123 10.5359 3.5
+      vertex -22.8395 11.8087 3.5
+      vertex -23.0634 12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
     outer loop
       vertex -24.56 11.0814 3.5
-      vertex -24.1123 10.5359 10
+      vertex -23.0634 12.0814 3.5
+      vertex -23.2297 12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 11.7038 3.5
+      vertex -23.2297 12.3926 3.5
+      vertex -23.3322 12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5668 11.5848 3.5
+      vertex -23.5668 10.0882 3.5
+      vertex -22.9444 9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 12.3792 3.5
+      vertex -23.3322 12.7303 3.5
+      vertex -23.3668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8927 14.4591 3.5
+      vertex -23.2297 13.7703 3.5
+      vertex -24.56 15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.2297 13.7703 3.5
+      vertex -24.8927 14.4591 3.5
+      vertex -23.3322 13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.8395 11.8087 3.5
       vertex -24.1123 10.5359 3.5
+      vertex -23.5668 10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.0976 13.7838 3.5
+      vertex -23.3322 13.4326 3.5
+      vertex -24.8927 14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0634 12.0814 3.5
+      vertex -24.56 11.0814 3.5
+      vertex -24.1123 10.5359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3322 13.4326 3.5
+      vertex -25.0976 13.7838 3.5
+      vertex -23.3668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.2297 12.3926 3.5
+      vertex -24.8927 11.7038 3.5
+      vertex -24.56 11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.1668 13.0815 3.5
+      vertex -23.3668 13.0815 3.5
+      vertex -25.0976 13.7838 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3322 12.7303 3.5
+      vertex -25.0976 12.3792 3.5
+      vertex -24.8927 11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3668 13.0815 3.5
+      vertex -25.1668 13.0815 3.5
+      vertex -25.0976 12.3792 3.5
     endloop
   endfacet
   facet normal 0.471398 0.881921 -0
@@ -2043,60 +2505,18 @@ solid OpenSCAD_Model
       vertex -23.5668 10.0882 3.5
     endloop
   endfacet
-  facet normal -0.0980169 0.995185 0
+  facet normal 0.634393 0.773011 -0
     outer loop
-      vertex -20.8644 9.55065 3.5
-      vertex -21.5668 9.48148 10
-      vertex -20.8644 9.55065 10
+      vertex -23.5668 10.0882 3.5
+      vertex -24.1123 10.5359 10
+      vertex -23.5668 10.0882 10
     endloop
   endfacet
-  facet normal -0.0980169 0.995185 0
+  facet normal 0.634393 0.773011 0
     outer loop
-      vertex -21.5668 9.48148 10
-      vertex -20.8644 9.55065 3.5
-      vertex -21.5668 9.48148 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex -24.56 15.0815 10
-      vertex -24.1123 15.6271 3.5
-      vertex -24.1123 15.6271 10
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex -24.1123 15.6271 3.5
-      vertex -24.56 15.0815 10
-      vertex -24.56 15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0.290283 0.956941 -0
-    outer loop
-      vertex -22.2691 9.55065 3.5
-      vertex -22.9444 9.75551 10
-      vertex -22.2691 9.55065 10
-    endloop
-  endfacet
-  facet normal 0.290283 0.956941 0
-    outer loop
-      vertex -22.9444 9.75551 10
-      vertex -22.2691 9.55065 3.5
-      vertex -22.9444 9.75551 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex -18.5735 15.0815 3.5
-      vertex -19.0212 15.6271 10
-      vertex -19.0212 15.6271 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex -19.0212 15.6271 10
-      vertex -18.5735 15.0815 3.5
-      vertex -18.5735 15.0815 10
+      vertex -24.1123 10.5359 10
+      vertex -23.5668 10.0882 3.5
+      vertex -24.1123 10.5359 3.5
     endloop
   endfacet
   facet normal -0.95694 -0.290284 0
@@ -2113,494 +2533,18 @@ solid OpenSCAD_Model
       vertex -18.0359 13.7838 10
     endloop
   endfacet
-  facet normal -0.290284 0.956941 0
+  facet normal -0.0980169 0.995185 0
     outer loop
-      vertex -20.1891 9.75551 3.5
+      vertex -20.8644 9.55065 3.5
+      vertex -21.5668 9.48148 10
       vertex -20.8644 9.55065 10
-      vertex -20.1891 9.75551 10
     endloop
   endfacet
-  facet normal -0.290284 0.956941 0
+  facet normal -0.0980169 0.995185 0
     outer loop
-      vertex -20.8644 9.55065 10
-      vertex -20.1891 9.75551 3.5
+      vertex -21.5668 9.48148 10
       vertex -20.8644 9.55065 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex -19.0212 10.5359 3.5
-      vertex -18.5735 11.0814 10
-      vertex -18.5735 11.0814 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex -18.5735 11.0814 10
-      vertex -19.0212 10.5359 3.5
-      vertex -19.0212 10.5359 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex -19.0212 10.5359 3.5
-      vertex -19.5667 10.0882 10
-      vertex -19.0212 10.5359 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex -19.5667 10.0882 10
-      vertex -19.0212 10.5359 3.5
-      vertex -19.5667 10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.7668 13.0815 3.5
-      vertex -17.9668 13.0815 3.5
-      vertex -18.0359 13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.8013 13.4326 3.5
-      vertex -18.0359 13.7838 3.5
-      vertex -18.2408 14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9668 13.0815 3.5
-      vertex -19.7668 13.0815 3.5
-      vertex -18.0359 12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.9038 13.7703 3.5
-      vertex -18.2408 14.4591 3.5
-      vertex -18.5735 15.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.8013 12.7303 3.5
-      vertex -18.0359 12.3792 3.5
-      vertex -19.7668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.0701 14.0815 3.5
-      vertex -18.5735 15.0815 3.5
-      vertex -19.0212 15.6271 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 12.3792 3.5
-      vertex -19.8013 12.7303 3.5
-      vertex -18.2408 11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.294 14.3543 3.5
-      vertex -19.0212 15.6271 3.5
-      vertex -19.5667 16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.9038 12.3926 3.5
-      vertex -18.2408 11.7038 3.5
-      vertex -19.8013 12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2408 11.7038 3.5
-      vertex -19.9038 12.3926 3.5
-      vertex -18.5735 11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 13.7838 3.5
-      vertex -19.8013 13.4326 3.5
-      vertex -19.7668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2408 14.4591 3.5
-      vertex -19.9038 13.7703 3.5
-      vertex -19.8013 13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5735 15.0815 3.5
-      vertex -20.0701 14.0815 3.5
-      vertex -19.9038 13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.5667 14.5781 3.5
-      vertex -19.5667 16.0748 3.5
-      vertex -20.1891 16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.0212 15.6271 3.5
-      vertex -20.294 14.3543 3.5
-      vertex -20.0701 14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.5667 16.0748 3.5
-      vertex -20.5667 14.5781 3.5
-      vertex -20.294 14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8779 14.7445 3.5
-      vertex -20.1891 16.4074 3.5
-      vertex -20.8644 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1891 16.4074 3.5
-      vertex -20.8779 14.7445 3.5
-      vertex -20.5667 14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8644 16.6123 3.5
-      vertex -21.2156 14.8469 3.5
-      vertex -20.8779 14.7445 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 16.6815 3.5
-      vertex -21.2156 14.8469 3.5
-      vertex -20.8644 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 16.6815 3.5
-      vertex -21.5668 14.8815 3.5
-      vertex -21.2156 14.8469 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 16.6815 3.5
-      vertex -21.9179 14.8469 3.5
-      vertex -21.5668 14.8815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.2691 16.6123 3.5
-      vertex -21.9179 14.8469 3.5
-      vertex -21.5668 16.6815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 14.8469 3.5
-      vertex -22.2691 16.6123 3.5
-      vertex -22.2556 14.7445 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.9444 16.4074 3.5
-      vertex -22.2556 14.7445 3.5
-      vertex -22.2691 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2556 14.7445 3.5
-      vertex -22.9444 16.4074 3.5
-      vertex -22.5668 14.5781 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -23.5668 16.0748 3.5
-      vertex -22.5668 14.5781 3.5
-      vertex -22.9444 16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.5668 14.5781 3.5
-      vertex -23.5668 16.0748 3.5
-      vertex -22.8395 14.3543 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.1123 15.6271 3.5
-      vertex -22.8395 14.3543 3.5
-      vertex -23.5668 16.0748 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.8395 14.3543 3.5
-      vertex -24.1123 15.6271 3.5
-      vertex -23.0634 14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0634 14.0815 3.5
-      vertex -24.56 15.0815 3.5
-      vertex -23.2297 13.7703 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.56 15.0815 3.5
-      vertex -23.0634 14.0815 3.5
-      vertex -24.1123 15.6271 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.0701 12.0814 3.5
-      vertex -18.5735 11.0814 3.5
-      vertex -19.9038 12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5735 11.0814 3.5
-      vertex -20.0701 12.0814 3.5
-      vertex -19.0212 10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.294 11.8087 3.5
-      vertex -19.0212 10.5359 3.5
-      vertex -20.0701 12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.0212 10.5359 3.5
-      vertex -20.294 11.8087 3.5
-      vertex -19.5667 10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.5667 11.5848 3.5
-      vertex -19.5667 10.0882 3.5
-      vertex -20.294 11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.5667 10.0882 3.5
-      vertex -20.5667 11.5848 3.5
-      vertex -20.1891 9.75551 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.8779 11.4185 3.5
-      vertex -20.1891 9.75551 3.5
-      vertex -20.5667 11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1891 9.75551 3.5
-      vertex -20.8779 11.4185 3.5
-      vertex -20.8644 9.55065 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -21.2156 11.3161 3.5
-      vertex -20.8644 9.55065 3.5
-      vertex -20.8779 11.4185 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -21.5668 11.2815 3.5
-      vertex -20.8644 9.55065 3.5
-      vertex -21.2156 11.3161 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 11.2815 3.5
       vertex -21.5668 9.48148 3.5
-      vertex -20.8644 9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 11.3161 3.5
-      vertex -21.5668 9.48148 3.5
-      vertex -21.5668 11.2815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 9.55065 3.5
-      vertex -21.9179 11.3161 3.5
-      vertex -22.2556 11.4185 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 11.3161 3.5
-      vertex -22.2691 9.55065 3.5
-      vertex -21.5668 9.48148 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.9444 9.75551 3.5
-      vertex -22.2556 11.4185 3.5
-      vertex -22.5668 11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 10.0882 3.5
-      vertex -22.5668 11.5848 3.5
-      vertex -22.8395 11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2556 11.4185 3.5
-      vertex -22.9444 9.75551 3.5
-      vertex -22.2691 9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.1123 10.5359 3.5
-      vertex -22.8395 11.8087 3.5
-      vertex -23.0634 12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 11.0814 3.5
-      vertex -23.0634 12.0814 3.5
-      vertex -23.2297 12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 11.7038 3.5
-      vertex -23.2297 12.3926 3.5
-      vertex -23.3322 12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.5668 11.5848 3.5
-      vertex -23.5668 10.0882 3.5
-      vertex -22.9444 9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 12.3792 3.5
-      vertex -23.3322 12.7303 3.5
-      vertex -23.3668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.8927 14.4591 3.5
-      vertex -23.2297 13.7703 3.5
-      vertex -24.56 15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.2297 13.7703 3.5
-      vertex -24.8927 14.4591 3.5
-      vertex -23.3322 13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.8395 11.8087 3.5
-      vertex -24.1123 10.5359 3.5
-      vertex -23.5668 10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -25.0976 13.7838 3.5
-      vertex -23.3322 13.4326 3.5
-      vertex -24.8927 14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0634 12.0814 3.5
-      vertex -24.56 11.0814 3.5
-      vertex -24.1123 10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3322 13.4326 3.5
-      vertex -25.0976 13.7838 3.5
-      vertex -23.3668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.2297 12.3926 3.5
-      vertex -24.8927 11.7038 3.5
-      vertex -24.56 11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.1668 13.0815 3.5
-      vertex -23.3668 13.0815 3.5
-      vertex -25.0976 13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3322 12.7303 3.5
-      vertex -25.0976 12.3792 3.5
-      vertex -24.8927 11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3668 13.0815 3.5
-      vertex -25.1668 13.0815 3.5
-      vertex -25.0976 12.3792 3.5
     endloop
   endfacet
   facet normal -0.881921 -0.471397 0
@@ -2615,6 +2559,48 @@ solid OpenSCAD_Model
       vertex -18.5735 15.0815 10
       vertex -18.2408 14.4591 3.5
       vertex -18.2408 14.4591 10
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -18.5735 15.0815 3.5
+      vertex -19.0212 15.6271 10
+      vertex -19.0212 15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -19.0212 15.6271 10
+      vertex -18.5735 15.0815 3.5
+      vertex -18.5735 15.0815 10
+    endloop
+  endfacet
+  facet normal -0.290284 0.956941 0
+    outer loop
+      vertex -20.1891 9.75551 3.5
+      vertex -20.8644 9.55065 10
+      vertex -20.1891 9.75551 10
+    endloop
+  endfacet
+  facet normal -0.290284 0.956941 0
+    outer loop
+      vertex -20.8644 9.55065 10
+      vertex -20.1891 9.75551 3.5
+      vertex -20.8644 9.55065 3.5
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex -19.5667 10.0882 3.5
+      vertex -20.1891 9.75551 10
+      vertex -19.5667 10.0882 10
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex -20.1891 9.75551 10
+      vertex -19.5667 10.0882 3.5
+      vertex -20.1891 9.75551 3.5
     endloop
   endfacet
   facet normal 0.0980171 0.995185 -0
@@ -2657,6 +2643,20 @@ solid OpenSCAD_Model
       vertex -18.2408 11.7038 10
       vertex -18.5735 11.0814 3.5
       vertex -18.5735 11.0814 10
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex -19.0212 10.5359 3.5
+      vertex -18.5735 11.0814 10
+      vertex -18.5735 11.0814 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex -18.5735 11.0814 10
+      vertex -19.0212 10.5359 3.5
+      vertex -19.0212 10.5359 10
     endloop
   endfacet
   facet normal -0.995185 -0.0980157 0
@@ -3135,18 +3135,18 @@ solid OpenSCAD_Model
       vertex -19.8013 -12.7303 3.5
     endloop
   endfacet
-  facet normal 0.95694 -0.290285 0
+  facet normal 0.77301 -0.634394 0
     outer loop
-      vertex -25.0976 -12.3792 10
-      vertex -24.8927 -11.7038 3.5
-      vertex -24.8927 -11.7038 10
+      vertex -24.56 -11.0814 10
+      vertex -24.1123 -10.5359 3.5
+      vertex -24.1123 -10.5359 10
     endloop
   endfacet
-  facet normal 0.95694 -0.290285 0
+  facet normal 0.77301 -0.634394 0
     outer loop
-      vertex -24.8927 -11.7038 3.5
-      vertex -25.0976 -12.3792 10
-      vertex -25.0976 -12.3792 3.5
+      vertex -24.1123 -10.5359 3.5
+      vertex -24.56 -11.0814 10
+      vertex -24.56 -11.0814 3.5
     endloop
   endfacet
   facet normal -0.634395 0.773009 0
@@ -3161,6 +3161,118 @@ solid OpenSCAD_Model
       vertex -19.5667 -16.0748 10
       vertex -19.0212 -15.6271 3.5
       vertex -19.5667 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 -0
+    outer loop
+      vertex -23.5668 -16.0748 3.5
+      vertex -24.1123 -15.6271 10
+      vertex -23.5668 -16.0748 10
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 0
+    outer loop
+      vertex -24.1123 -15.6271 10
+      vertex -23.5668 -16.0748 3.5
+      vertex -24.1123 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 0
+    outer loop
+      vertex -19.5667 -10.0882 3.5
+      vertex -19.0212 -10.5359 10
+      vertex -19.5667 -10.0882 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 -0
+    outer loop
+      vertex -19.0212 -10.5359 10
+      vertex -19.5667 -10.0882 3.5
+      vertex -19.0212 -10.5359 3.5
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980157 0
+    outer loop
+      vertex -25.0976 -13.7838 10
+      vertex -25.1668 -13.0815 3.5
+      vertex -25.1668 -13.0815 10
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980157 0
+    outer loop
+      vertex -25.1668 -13.0815 3.5
+      vertex -25.0976 -13.7838 10
+      vertex -25.0976 -13.7838 3.5
+    endloop
+  endfacet
+  facet normal -0.0980182 0.995185 0
+    outer loop
+      vertex -20.8644 -16.6123 3.5
+      vertex -21.5668 -16.6815 10
+      vertex -20.8644 -16.6123 10
+    endloop
+  endfacet
+  facet normal -0.0980182 0.995185 0
+    outer loop
+      vertex -21.5668 -16.6815 10
+      vertex -20.8644 -16.6123 3.5
+      vertex -21.5668 -16.6815 3.5
+    endloop
+  endfacet
+  facet normal 0.290284 0.956941 -0
+    outer loop
+      vertex -22.2691 -16.6123 3.5
+      vertex -22.9444 -16.4074 10
+      vertex -22.2691 -16.6123 10
+    endloop
+  endfacet
+  facet normal 0.290284 0.956941 0
+    outer loop
+      vertex -22.9444 -16.4074 10
+      vertex -22.2691 -16.6123 3.5
+      vertex -22.9444 -16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0.290283 -0.956941 0
+    outer loop
+      vertex -22.9444 -9.75551 3.5
+      vertex -22.2691 -9.55065 10
+      vertex -22.9444 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0.290283 -0.956941 0
+    outer loop
+      vertex -22.2691 -9.55065 10
+      vertex -22.9444 -9.75551 3.5
+      vertex -22.2691 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0.95694 -0.290285 0
+    outer loop
+      vertex -25.0976 -12.3792 10
+      vertex -24.8927 -11.7038 3.5
+      vertex -24.8927 -11.7038 10
+    endloop
+  endfacet
+  facet normal 0.95694 -0.290285 0
+    outer loop
+      vertex -24.8927 -11.7038 3.5
+      vertex -25.0976 -12.3792 10
+      vertex -25.0976 -12.3792 3.5
+    endloop
+  endfacet
+  facet normal 0.881921 -0.471397 0
+    outer loop
+      vertex -24.8927 -11.7038 10
+      vertex -24.56 -11.0814 3.5
+      vertex -24.56 -11.0814 10
+    endloop
+  endfacet
+  facet normal 0.881921 -0.471397 0
+    outer loop
+      vertex -24.56 -11.0814 3.5
+      vertex -24.8927 -11.7038 10
+      vertex -24.8927 -11.7038 3.5
     endloop
   endfacet
   facet normal 0.995185 -0.0980157 0
@@ -3191,101 +3303,17 @@ solid OpenSCAD_Model
       vertex -24.56 -15.0815 3.5
     endloop
   endfacet
-  facet normal 0.290284 0.956941 -0
-    outer loop
-      vertex -22.2691 -16.6123 3.5
-      vertex -22.9444 -16.4074 10
-      vertex -22.2691 -16.6123 10
-    endloop
-  endfacet
-  facet normal 0.290284 0.956941 0
-    outer loop
-      vertex -22.9444 -16.4074 10
-      vertex -22.2691 -16.6123 3.5
-      vertex -22.9444 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal -0.471395 0.881922 0
-    outer loop
-      vertex -19.5667 -16.0748 3.5
-      vertex -20.1891 -16.4074 10
-      vertex -19.5667 -16.0748 10
-    endloop
-  endfacet
-  facet normal -0.471395 0.881922 0
-    outer loop
-      vertex -20.1891 -16.4074 10
-      vertex -19.5667 -16.0748 3.5
-      vertex -20.1891 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex -24.1123 -10.5359 3.5
-      vertex -23.5668 -10.0882 10
-      vertex -24.1123 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex -23.5668 -10.0882 10
-      vertex -24.1123 -10.5359 3.5
-      vertex -23.5668 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0.471397 -0.881921 0
-    outer loop
-      vertex -20.1891 -9.75551 3.5
-      vertex -19.5667 -10.0882 10
-      vertex -20.1891 -9.75551 10
-    endloop
-  endfacet
-  facet normal -0.471397 -0.881921 -0
-    outer loop
-      vertex -19.5667 -10.0882 10
-      vertex -20.1891 -9.75551 3.5
-      vertex -19.5667 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex -24.8927 -11.7038 10
-      vertex -24.56 -11.0814 3.5
-      vertex -24.56 -11.0814 10
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex -24.56 -11.0814 3.5
-      vertex -24.8927 -11.7038 10
-      vertex -24.8927 -11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0.995185 0.0980157 0
-    outer loop
-      vertex -25.0976 -13.7838 10
-      vertex -25.1668 -13.0815 3.5
-      vertex -25.1668 -13.0815 10
-    endloop
-  endfacet
-  facet normal 0.995185 0.0980157 0
-    outer loop
-      vertex -25.1668 -13.0815 3.5
-      vertex -25.0976 -13.7838 10
-      vertex -25.0976 -13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 -0
-    outer loop
-      vertex -23.5668 -16.0748 3.5
-      vertex -24.1123 -15.6271 10
-      vertex -23.5668 -16.0748 10
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 0
+  facet normal 0.77301 0.634394 0
     outer loop
       vertex -24.1123 -15.6271 10
-      vertex -23.5668 -16.0748 3.5
+      vertex -24.56 -15.0815 3.5
+      vertex -24.56 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex -24.56 -15.0815 3.5
+      vertex -24.1123 -15.6271 10
       vertex -24.1123 -15.6271 3.5
     endloop
   endfacet
@@ -3315,6 +3343,20 @@ solid OpenSCAD_Model
       vertex -20.8644 -16.6123 10
       vertex -20.1891 -16.4074 3.5
       vertex -20.8644 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal -0.471395 0.881922 0
+    outer loop
+      vertex -19.5667 -16.0748 3.5
+      vertex -20.1891 -16.4074 10
+      vertex -19.5667 -16.0748 10
+    endloop
+  endfacet
+  facet normal -0.471395 0.881922 0
+    outer loop
+      vertex -20.1891 -16.4074 10
+      vertex -19.5667 -16.0748 3.5
+      vertex -20.1891 -16.4074 3.5
     endloop
   endfacet
   facet normal 0.0980185 0.995185 -0
@@ -3345,32 +3387,452 @@ solid OpenSCAD_Model
       vertex -23.5668 -16.0748 3.5
     endloop
   endfacet
-  facet normal -0.0980182 0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex -20.8644 -16.6123 3.5
-      vertex -21.5668 -16.6815 10
-      vertex -20.8644 -16.6123 10
+      vertex -19.7668 -13.0815 3.5
+      vertex -17.9668 -13.0815 3.5
+      vertex -18.0359 -12.3792 3.5
     endloop
   endfacet
-  facet normal -0.0980182 0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex -21.5668 -16.6815 10
+      vertex -19.8013 -12.7303 3.5
+      vertex -18.0359 -12.3792 3.5
+      vertex -18.2408 -11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 -13.0815 3.5
+      vertex -19.7668 -13.0815 3.5
+      vertex -18.0359 -13.7838 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.9038 -12.3926 3.5
+      vertex -18.2408 -11.7038 3.5
+      vertex -18.5735 -11.0814 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.8013 -13.4326 3.5
+      vertex -18.0359 -13.7838 3.5
+      vertex -19.7668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.0701 -12.0814 3.5
+      vertex -18.5735 -11.0814 3.5
+      vertex -19.0212 -10.5359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0359 -13.7838 3.5
+      vertex -19.8013 -13.4326 3.5
+      vertex -18.2408 -14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.294 -11.8087 3.5
+      vertex -19.0212 -10.5359 3.5
+      vertex -19.5667 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.9038 -13.7703 3.5
+      vertex -18.2408 -14.4591 3.5
+      vertex -19.8013 -13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2408 -14.4591 3.5
+      vertex -19.9038 -13.7703 3.5
+      vertex -18.5735 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0359 -12.3792 3.5
+      vertex -19.8013 -12.7303 3.5
+      vertex -19.7668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2408 -11.7038 3.5
+      vertex -19.9038 -12.3926 3.5
+      vertex -19.8013 -12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 -11.0814 3.5
+      vertex -20.0701 -12.0814 3.5
+      vertex -19.9038 -12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5667 -11.5848 3.5
+      vertex -19.5667 -10.0882 3.5
+      vertex -20.1891 -9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 -10.5359 3.5
+      vertex -20.294 -11.8087 3.5
+      vertex -20.0701 -12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 -10.0882 3.5
+      vertex -20.5667 -11.5848 3.5
+      vertex -20.294 -11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8779 -11.4185 3.5
+      vertex -20.1891 -9.75551 3.5
+      vertex -20.8644 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1891 -9.75551 3.5
+      vertex -20.8779 -11.4185 3.5
+      vertex -20.5667 -11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8644 -9.55065 3.5
+      vertex -21.2156 -11.3161 3.5
+      vertex -20.8779 -11.4185 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 -9.48148 3.5
+      vertex -21.2156 -11.3161 3.5
+      vertex -20.8644 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 -9.48148 3.5
+      vertex -21.5668 -11.2815 3.5
+      vertex -21.2156 -11.3161 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 -9.48148 3.5
+      vertex -21.9179 -11.3161 3.5
+      vertex -21.5668 -11.2815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.2691 -9.55065 3.5
+      vertex -21.9179 -11.3161 3.5
+      vertex -21.5668 -9.48148 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 -11.3161 3.5
+      vertex -22.2691 -9.55065 3.5
+      vertex -22.2556 -11.4185 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.9444 -9.75551 3.5
+      vertex -22.2556 -11.4185 3.5
+      vertex -22.2691 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2556 -11.4185 3.5
+      vertex -22.9444 -9.75551 3.5
+      vertex -22.5668 -11.5848 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.5668 -10.0882 3.5
+      vertex -22.5668 -11.5848 3.5
+      vertex -22.9444 -9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5668 -11.5848 3.5
+      vertex -23.5668 -10.0882 3.5
+      vertex -22.8395 -11.8087 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.1123 -10.5359 3.5
+      vertex -22.8395 -11.8087 3.5
+      vertex -23.5668 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.8395 -11.8087 3.5
+      vertex -24.1123 -10.5359 3.5
+      vertex -23.0634 -12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0634 -12.0814 3.5
+      vertex -24.56 -11.0814 3.5
+      vertex -23.2297 -12.3926 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.56 -11.0814 3.5
+      vertex -23.0634 -12.0814 3.5
+      vertex -24.1123 -10.5359 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.0701 -14.0815 3.5
+      vertex -18.5735 -15.0815 3.5
+      vertex -19.9038 -13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 -15.0815 3.5
+      vertex -20.0701 -14.0815 3.5
+      vertex -19.0212 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.294 -14.3543 3.5
+      vertex -19.0212 -15.6271 3.5
+      vertex -20.0701 -14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 -15.6271 3.5
+      vertex -20.294 -14.3543 3.5
+      vertex -19.5667 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.5667 -14.5781 3.5
+      vertex -19.5667 -16.0748 3.5
+      vertex -20.294 -14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 -16.0748 3.5
+      vertex -20.5667 -14.5781 3.5
+      vertex -20.1891 -16.4074 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8779 -14.7445 3.5
+      vertex -20.1891 -16.4074 3.5
+      vertex -20.5667 -14.5781 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1891 -16.4074 3.5
+      vertex -20.8779 -14.7445 3.5
       vertex -20.8644 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.2156 -14.8469 3.5
+      vertex -20.8644 -16.6123 3.5
+      vertex -20.8779 -14.7445 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5668 -14.8815 3.5
+      vertex -20.8644 -16.6123 3.5
+      vertex -21.2156 -14.8469 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 -14.8815 3.5
+      vertex -21.5668 -16.6815 3.5
+      vertex -20.8644 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 -14.8469 3.5
+      vertex -21.5668 -16.6815 3.5
+      vertex -21.5668 -14.8815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 -16.6123 3.5
+      vertex -21.9179 -14.8469 3.5
+      vertex -22.2556 -14.7445 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9179 -14.8469 3.5
+      vertex -22.2691 -16.6123 3.5
       vertex -21.5668 -16.6815 3.5
     endloop
   endfacet
-  facet normal 0.77301 -0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex -24.56 -11.0814 10
-      vertex -24.1123 -10.5359 3.5
-      vertex -24.1123 -10.5359 10
+      vertex -22.9444 -16.4074 3.5
+      vertex -22.2556 -14.7445 3.5
+      vertex -22.5668 -14.5781 3.5
     endloop
   endfacet
-  facet normal 0.77301 -0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex -24.1123 -10.5359 3.5
-      vertex -24.56 -11.0814 10
+      vertex -23.5668 -16.0748 3.5
+      vertex -22.5668 -14.5781 3.5
+      vertex -22.8395 -14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2556 -14.7445 3.5
+      vertex -22.9444 -16.4074 3.5
+      vertex -22.2691 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1123 -15.6271 3.5
+      vertex -22.8395 -14.3543 3.5
+      vertex -23.0634 -14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.56 -15.0815 3.5
+      vertex -23.0634 -14.0815 3.5
+      vertex -23.2297 -13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 -14.4591 3.5
+      vertex -23.2297 -13.7703 3.5
+      vertex -23.3322 -13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5668 -14.5781 3.5
+      vertex -23.5668 -16.0748 3.5
+      vertex -22.9444 -16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 -13.7838 3.5
+      vertex -23.3322 -13.4326 3.5
+      vertex -23.3668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8927 -11.7038 3.5
+      vertex -23.2297 -12.3926 3.5
       vertex -24.56 -11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.2297 -12.3926 3.5
+      vertex -24.8927 -11.7038 3.5
+      vertex -23.3322 -12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.8395 -14.3543 3.5
+      vertex -24.1123 -15.6271 3.5
+      vertex -23.5668 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.0976 -12.3792 3.5
+      vertex -23.3322 -12.7303 3.5
+      vertex -24.8927 -11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0634 -14.0815 3.5
+      vertex -24.56 -15.0815 3.5
+      vertex -24.1123 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3322 -12.7303 3.5
+      vertex -25.0976 -12.3792 3.5
+      vertex -23.3668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.2297 -13.7703 3.5
+      vertex -24.8927 -14.4591 3.5
+      vertex -24.56 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.1668 -13.0815 3.5
+      vertex -23.3668 -13.0815 3.5
+      vertex -25.0976 -12.3792 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3322 -13.4326 3.5
+      vertex -25.0976 -13.7838 3.5
+      vertex -24.8927 -14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3668 -13.0815 3.5
+      vertex -25.1668 -13.0815 3.5
+      vertex -25.0976 -13.7838 3.5
     endloop
   endfacet
   facet normal 0.471398 -0.881921 0
@@ -3387,6 +3849,34 @@ solid OpenSCAD_Model
       vertex -22.9444 -9.75551 3.5
     endloop
   endfacet
+  facet normal 0.634393 -0.773011 0
+    outer loop
+      vertex -24.1123 -10.5359 3.5
+      vertex -23.5668 -10.0882 10
+      vertex -24.1123 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0.634393 -0.773011 0
+    outer loop
+      vertex -23.5668 -10.0882 10
+      vertex -24.1123 -10.5359 3.5
+      vertex -23.5668 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 0.290284 0
+    outer loop
+      vertex -18.2408 -14.4591 3.5
+      vertex -18.0359 -13.7838 10
+      vertex -18.0359 -13.7838 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 0.290284 0
+    outer loop
+      vertex -18.0359 -13.7838 10
+      vertex -18.2408 -14.4591 3.5
+      vertex -18.2408 -14.4591 10
+    endloop
+  endfacet
   facet normal -0.0980169 -0.995185 0
     outer loop
       vertex -21.5668 -9.48148 3.5
@@ -3401,32 +3891,18 @@ solid OpenSCAD_Model
       vertex -20.8644 -9.55065 3.5
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal -0.881921 0.471397 0
     outer loop
-      vertex -24.1123 -15.6271 10
-      vertex -24.56 -15.0815 3.5
-      vertex -24.56 -15.0815 10
+      vertex -18.5735 -15.0815 3.5
+      vertex -18.2408 -14.4591 10
+      vertex -18.2408 -14.4591 3.5
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal -0.881921 0.471397 0
     outer loop
-      vertex -24.56 -15.0815 3.5
-      vertex -24.1123 -15.6271 10
-      vertex -24.1123 -15.6271 3.5
-    endloop
-  endfacet
-  facet normal 0.290283 -0.956941 0
-    outer loop
-      vertex -22.9444 -9.75551 3.5
-      vertex -22.2691 -9.55065 10
-      vertex -22.9444 -9.75551 10
-    endloop
-  endfacet
-  facet normal 0.290283 -0.956941 0
-    outer loop
-      vertex -22.2691 -9.55065 10
-      vertex -22.9444 -9.75551 3.5
-      vertex -22.2691 -9.55065 3.5
+      vertex -18.2408 -14.4591 10
+      vertex -18.5735 -15.0815 3.5
+      vertex -18.5735 -15.0815 10
     endloop
   endfacet
   facet normal -0.77301 0.634394 0
@@ -3443,20 +3919,6 @@ solid OpenSCAD_Model
       vertex -19.0212 -15.6271 10
     endloop
   endfacet
-  facet normal -0.95694 0.290284 0
-    outer loop
-      vertex -18.2408 -14.4591 3.5
-      vertex -18.0359 -13.7838 10
-      vertex -18.0359 -13.7838 3.5
-    endloop
-  endfacet
-  facet normal -0.95694 0.290284 0
-    outer loop
-      vertex -18.0359 -13.7838 10
-      vertex -18.2408 -14.4591 3.5
-      vertex -18.2408 -14.4591 10
-    endloop
-  endfacet
   facet normal -0.290284 -0.956941 0
     outer loop
       vertex -20.8644 -9.55065 3.5
@@ -3471,494 +3933,18 @@ solid OpenSCAD_Model
       vertex -20.1891 -9.75551 3.5
     endloop
   endfacet
-  facet normal -0.77301 -0.634394 0
+  facet normal -0.471397 -0.881921 0
     outer loop
-      vertex -18.5735 -11.0814 3.5
-      vertex -19.0212 -10.5359 10
-      vertex -19.0212 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex -19.0212 -10.5359 10
-      vertex -18.5735 -11.0814 3.5
-      vertex -18.5735 -11.0814 10
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 0
-    outer loop
-      vertex -19.5667 -10.0882 3.5
-      vertex -19.0212 -10.5359 10
+      vertex -20.1891 -9.75551 3.5
       vertex -19.5667 -10.0882 10
+      vertex -20.1891 -9.75551 10
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 -0
+  facet normal -0.471397 -0.881921 -0
     outer loop
-      vertex -19.0212 -10.5359 10
-      vertex -19.5667 -10.0882 3.5
-      vertex -19.0212 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.7668 -13.0815 3.5
-      vertex -17.9668 -13.0815 3.5
-      vertex -18.0359 -12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.8013 -12.7303 3.5
-      vertex -18.0359 -12.3792 3.5
-      vertex -18.2408 -11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9668 -13.0815 3.5
-      vertex -19.7668 -13.0815 3.5
-      vertex -18.0359 -13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.9038 -12.3926 3.5
-      vertex -18.2408 -11.7038 3.5
-      vertex -18.5735 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.8013 -13.4326 3.5
-      vertex -18.0359 -13.7838 3.5
-      vertex -19.7668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.0701 -12.0814 3.5
-      vertex -18.5735 -11.0814 3.5
-      vertex -19.0212 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 -13.7838 3.5
-      vertex -19.8013 -13.4326 3.5
-      vertex -18.2408 -14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.294 -11.8087 3.5
-      vertex -19.0212 -10.5359 3.5
-      vertex -19.5667 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.9038 -13.7703 3.5
-      vertex -18.2408 -14.4591 3.5
-      vertex -19.8013 -13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2408 -14.4591 3.5
-      vertex -19.9038 -13.7703 3.5
-      vertex -18.5735 -15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 -12.3792 3.5
-      vertex -19.8013 -12.7303 3.5
-      vertex -19.7668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2408 -11.7038 3.5
-      vertex -19.9038 -12.3926 3.5
-      vertex -19.8013 -12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5735 -11.0814 3.5
-      vertex -20.0701 -12.0814 3.5
-      vertex -19.9038 -12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.5667 -11.5848 3.5
-      vertex -19.5667 -10.0882 3.5
+      vertex -19.5667 -10.0882 10
       vertex -20.1891 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.0212 -10.5359 3.5
-      vertex -20.294 -11.8087 3.5
-      vertex -20.0701 -12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
       vertex -19.5667 -10.0882 3.5
-      vertex -20.5667 -11.5848 3.5
-      vertex -20.294 -11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8779 -11.4185 3.5
-      vertex -20.1891 -9.75551 3.5
-      vertex -20.8644 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1891 -9.75551 3.5
-      vertex -20.8779 -11.4185 3.5
-      vertex -20.5667 -11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8644 -9.55065 3.5
-      vertex -21.2156 -11.3161 3.5
-      vertex -20.8779 -11.4185 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 -9.48148 3.5
-      vertex -21.2156 -11.3161 3.5
-      vertex -20.8644 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 -9.48148 3.5
-      vertex -21.5668 -11.2815 3.5
-      vertex -21.2156 -11.3161 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 -9.48148 3.5
-      vertex -21.9179 -11.3161 3.5
-      vertex -21.5668 -11.2815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.2691 -9.55065 3.5
-      vertex -21.9179 -11.3161 3.5
-      vertex -21.5668 -9.48148 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 -11.3161 3.5
-      vertex -22.2691 -9.55065 3.5
-      vertex -22.2556 -11.4185 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.9444 -9.75551 3.5
-      vertex -22.2556 -11.4185 3.5
-      vertex -22.2691 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2556 -11.4185 3.5
-      vertex -22.9444 -9.75551 3.5
-      vertex -22.5668 -11.5848 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -23.5668 -10.0882 3.5
-      vertex -22.5668 -11.5848 3.5
-      vertex -22.9444 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.5668 -11.5848 3.5
-      vertex -23.5668 -10.0882 3.5
-      vertex -22.8395 -11.8087 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.1123 -10.5359 3.5
-      vertex -22.8395 -11.8087 3.5
-      vertex -23.5668 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.8395 -11.8087 3.5
-      vertex -24.1123 -10.5359 3.5
-      vertex -23.0634 -12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0634 -12.0814 3.5
-      vertex -24.56 -11.0814 3.5
-      vertex -23.2297 -12.3926 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.56 -11.0814 3.5
-      vertex -23.0634 -12.0814 3.5
-      vertex -24.1123 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.0701 -14.0815 3.5
-      vertex -18.5735 -15.0815 3.5
-      vertex -19.9038 -13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5735 -15.0815 3.5
-      vertex -20.0701 -14.0815 3.5
-      vertex -19.0212 -15.6271 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.294 -14.3543 3.5
-      vertex -19.0212 -15.6271 3.5
-      vertex -20.0701 -14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.0212 -15.6271 3.5
-      vertex -20.294 -14.3543 3.5
-      vertex -19.5667 -16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.5667 -14.5781 3.5
-      vertex -19.5667 -16.0748 3.5
-      vertex -20.294 -14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.5667 -16.0748 3.5
-      vertex -20.5667 -14.5781 3.5
-      vertex -20.1891 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.8779 -14.7445 3.5
-      vertex -20.1891 -16.4074 3.5
-      vertex -20.5667 -14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1891 -16.4074 3.5
-      vertex -20.8779 -14.7445 3.5
-      vertex -20.8644 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -21.2156 -14.8469 3.5
-      vertex -20.8644 -16.6123 3.5
-      vertex -20.8779 -14.7445 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -21.5668 -14.8815 3.5
-      vertex -20.8644 -16.6123 3.5
-      vertex -21.2156 -14.8469 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 -14.8815 3.5
-      vertex -21.5668 -16.6815 3.5
-      vertex -20.8644 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 -14.8469 3.5
-      vertex -21.5668 -16.6815 3.5
-      vertex -21.5668 -14.8815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 -16.6123 3.5
-      vertex -21.9179 -14.8469 3.5
-      vertex -22.2556 -14.7445 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.9179 -14.8469 3.5
-      vertex -22.2691 -16.6123 3.5
-      vertex -21.5668 -16.6815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.9444 -16.4074 3.5
-      vertex -22.2556 -14.7445 3.5
-      vertex -22.5668 -14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 -16.0748 3.5
-      vertex -22.5668 -14.5781 3.5
-      vertex -22.8395 -14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2556 -14.7445 3.5
-      vertex -22.9444 -16.4074 3.5
-      vertex -22.2691 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.1123 -15.6271 3.5
-      vertex -22.8395 -14.3543 3.5
-      vertex -23.0634 -14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 -15.0815 3.5
-      vertex -23.0634 -14.0815 3.5
-      vertex -23.2297 -13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 -14.4591 3.5
-      vertex -23.2297 -13.7703 3.5
-      vertex -23.3322 -13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.5668 -14.5781 3.5
-      vertex -23.5668 -16.0748 3.5
-      vertex -22.9444 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 -13.7838 3.5
-      vertex -23.3322 -13.4326 3.5
-      vertex -23.3668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.8927 -11.7038 3.5
-      vertex -23.2297 -12.3926 3.5
-      vertex -24.56 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.2297 -12.3926 3.5
-      vertex -24.8927 -11.7038 3.5
-      vertex -23.3322 -12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.8395 -14.3543 3.5
-      vertex -24.1123 -15.6271 3.5
-      vertex -23.5668 -16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -25.0976 -12.3792 3.5
-      vertex -23.3322 -12.7303 3.5
-      vertex -24.8927 -11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0634 -14.0815 3.5
-      vertex -24.56 -15.0815 3.5
-      vertex -24.1123 -15.6271 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3322 -12.7303 3.5
-      vertex -25.0976 -12.3792 3.5
-      vertex -23.3668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.2297 -13.7703 3.5
-      vertex -24.8927 -14.4591 3.5
-      vertex -24.56 -15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.1668 -13.0815 3.5
-      vertex -23.3668 -13.0815 3.5
-      vertex -25.0976 -12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3322 -13.4326 3.5
-      vertex -25.0976 -13.7838 3.5
-      vertex -24.8927 -14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.3668 -13.0815 3.5
-      vertex -25.1668 -13.0815 3.5
-      vertex -25.0976 -13.7838 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex -18.5735 -15.0815 3.5
-      vertex -18.2408 -14.4591 10
-      vertex -18.2408 -14.4591 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex -18.2408 -14.4591 10
-      vertex -18.5735 -15.0815 3.5
-      vertex -18.5735 -15.0815 10
     endloop
   endfacet
   facet normal 0.0980171 -0.995185 0
@@ -4001,6 +3987,20 @@ solid OpenSCAD_Model
       vertex -18.5735 -11.0814 10
       vertex -18.2408 -11.7038 3.5
       vertex -18.2408 -11.7038 10
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -18.5735 -11.0814 3.5
+      vertex -19.0212 -10.5359 10
+      vertex -19.0212 -10.5359 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -19.0212 -10.5359 10
+      vertex -18.5735 -11.0814 3.5
+      vertex -18.5735 -11.0814 10
     endloop
   endfacet
   facet normal -0.995185 0.0980157 0
@@ -4479,18 +4479,18 @@ solid OpenSCAD_Model
       vertex -12.3926 -19.9038 0
     endloop
   endfacet
-  facet normal -0.290285 0.95694 0
+  facet normal -0.634394 0.77301 0
     outer loop
-      vertex -11.7038 -24.8927 3.5
-      vertex -12.3792 -25.0976 10
-      vertex -11.7038 -24.8927 10
+      vertex -10.5359 -24.1123 3.5
+      vertex -11.0814 -24.56 10
+      vertex -10.5359 -24.1123 10
     endloop
   endfacet
-  facet normal -0.290285 0.95694 0
+  facet normal -0.634394 0.77301 0
     outer loop
-      vertex -12.3792 -25.0976 10
-      vertex -11.7038 -24.8927 3.5
-      vertex -12.3792 -25.0976 3.5
+      vertex -11.0814 -24.56 10
+      vertex -10.5359 -24.1123 3.5
+      vertex -11.0814 -24.56 3.5
     endloop
   endfacet
   facet normal 0.773009 -0.634395 0
@@ -4505,6 +4505,118 @@ solid OpenSCAD_Model
       vertex -15.6271 -19.0212 3.5
       vertex -16.0748 -19.5667 10
       vertex -16.0748 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex -15.6271 -24.1123 10
+      vertex -16.0748 -23.5668 3.5
+      vertex -16.0748 -23.5668 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex -16.0748 -23.5668 3.5
+      vertex -15.6271 -24.1123 10
+      vertex -15.6271 -24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -10.0882 -19.5667 3.5
+      vertex -10.5359 -19.0212 10
+      vertex -10.5359 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex -10.5359 -19.0212 10
+      vertex -10.0882 -19.5667 3.5
+      vertex -10.0882 -19.5667 10
+    endloop
+  endfacet
+  facet normal 0.0980157 0.995185 -0
+    outer loop
+      vertex -13.0815 -25.1668 3.5
+      vertex -13.7838 -25.0976 10
+      vertex -13.0815 -25.1668 10
+    endloop
+  endfacet
+  facet normal 0.0980157 0.995185 0
+    outer loop
+      vertex -13.7838 -25.0976 10
+      vertex -13.0815 -25.1668 3.5
+      vertex -13.7838 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980182 0
+    outer loop
+      vertex -16.6815 -21.5668 10
+      vertex -16.6123 -20.8644 3.5
+      vertex -16.6123 -20.8644 10
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980182 0
+    outer loop
+      vertex -16.6123 -20.8644 3.5
+      vertex -16.6815 -21.5668 10
+      vertex -16.6815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0.956941 0.290284 0
+    outer loop
+      vertex -16.4074 -22.9444 10
+      vertex -16.6123 -22.2691 3.5
+      vertex -16.6123 -22.2691 10
+    endloop
+  endfacet
+  facet normal 0.956941 0.290284 0
+    outer loop
+      vertex -16.6123 -22.2691 3.5
+      vertex -16.4074 -22.9444 10
+      vertex -16.4074 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 0.290283 0
+    outer loop
+      vertex -9.75551 -22.9444 3.5
+      vertex -9.55065 -22.2691 10
+      vertex -9.55065 -22.2691 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 0.290283 0
+    outer loop
+      vertex -9.55065 -22.2691 10
+      vertex -9.75551 -22.9444 3.5
+      vertex -9.75551 -22.9444 10
+    endloop
+  endfacet
+  facet normal -0.290285 0.95694 0
+    outer loop
+      vertex -11.7038 -24.8927 3.5
+      vertex -12.3792 -25.0976 10
+      vertex -11.7038 -24.8927 10
+    endloop
+  endfacet
+  facet normal -0.290285 0.95694 0
+    outer loop
+      vertex -12.3792 -25.0976 10
+      vertex -11.7038 -24.8927 3.5
+      vertex -12.3792 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex -11.0814 -24.56 3.5
+      vertex -11.7038 -24.8927 10
+      vertex -11.0814 -24.56 10
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex -11.7038 -24.8927 10
+      vertex -11.0814 -24.56 3.5
+      vertex -11.7038 -24.8927 3.5
     endloop
   endfacet
   facet normal -0.0980157 0.995185 0
@@ -4535,101 +4647,17 @@ solid OpenSCAD_Model
       vertex -15.0815 -24.56 3.5
     endloop
   endfacet
-  facet normal 0.956941 0.290284 0
+  facet normal 0.634394 0.77301 -0
     outer loop
-      vertex -16.4074 -22.9444 10
-      vertex -16.6123 -22.2691 3.5
-      vertex -16.6123 -22.2691 10
+      vertex -15.0815 -24.56 3.5
+      vertex -15.6271 -24.1123 10
+      vertex -15.0815 -24.56 10
     endloop
   endfacet
-  facet normal 0.956941 0.290284 0
-    outer loop
-      vertex -16.6123 -22.2691 3.5
-      vertex -16.4074 -22.9444 10
-      vertex -16.4074 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471395 0
-    outer loop
-      vertex -16.4074 -20.1891 10
-      vertex -16.0748 -19.5667 3.5
-      vertex -16.0748 -19.5667 10
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471395 0
-    outer loop
-      vertex -16.0748 -19.5667 3.5
-      vertex -16.4074 -20.1891 10
-      vertex -16.4074 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex -10.5359 -24.1123 3.5
-      vertex -10.0882 -23.5668 10
-      vertex -10.0882 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex -10.0882 -23.5668 10
-      vertex -10.5359 -24.1123 3.5
-      vertex -10.5359 -24.1123 10
-    endloop
-  endfacet
-  facet normal -0.881921 -0.471397 0
-    outer loop
-      vertex -9.75551 -20.1891 3.5
-      vertex -10.0882 -19.5667 10
-      vertex -10.0882 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 -0.471397 0
-    outer loop
-      vertex -10.0882 -19.5667 10
-      vertex -9.75551 -20.1891 3.5
-      vertex -9.75551 -20.1891 10
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex -11.0814 -24.56 3.5
-      vertex -11.7038 -24.8927 10
-      vertex -11.0814 -24.56 10
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex -11.7038 -24.8927 10
-      vertex -11.0814 -24.56 3.5
-      vertex -11.7038 -24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0.0980157 0.995185 -0
-    outer loop
-      vertex -13.0815 -25.1668 3.5
-      vertex -13.7838 -25.0976 10
-      vertex -13.0815 -25.1668 10
-    endloop
-  endfacet
-  facet normal 0.0980157 0.995185 0
-    outer loop
-      vertex -13.7838 -25.0976 10
-      vertex -13.0815 -25.1668 3.5
-      vertex -13.7838 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal 0.634394 0.77301 0
     outer loop
       vertex -15.6271 -24.1123 10
-      vertex -16.0748 -23.5668 3.5
-      vertex -16.0748 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex -16.0748 -23.5668 3.5
-      vertex -15.6271 -24.1123 10
+      vertex -15.0815 -24.56 3.5
       vertex -15.6271 -24.1123 3.5
     endloop
   endfacet
@@ -4661,6 +4689,20 @@ solid OpenSCAD_Model
       vertex -16.6123 -20.8644 3.5
     endloop
   endfacet
+  facet normal 0.881922 -0.471395 0
+    outer loop
+      vertex -16.4074 -20.1891 10
+      vertex -16.0748 -19.5667 3.5
+      vertex -16.0748 -19.5667 10
+    endloop
+  endfacet
+  facet normal 0.881922 -0.471395 0
+    outer loop
+      vertex -16.0748 -19.5667 3.5
+      vertex -16.4074 -20.1891 10
+      vertex -16.4074 -20.1891 3.5
+    endloop
+  endfacet
   facet normal 0.995185 0.0980185 0
     outer loop
       vertex -16.6123 -22.2691 10
@@ -4689,32 +4731,452 @@ solid OpenSCAD_Model
       vertex -16.0748 -23.5668 3.5
     endloop
   endfacet
-  facet normal 0.995185 -0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.6815 -21.5668 10
-      vertex -16.6123 -20.8644 3.5
-      vertex -16.6123 -20.8644 10
+      vertex -11.2815 -21.5668 3.5
+      vertex -9.48148 -21.5668 3.5
+      vertex -9.55065 -20.8644 3.5
     endloop
   endfacet
-  facet normal 0.995185 -0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.6123 -20.8644 3.5
-      vertex -16.6815 -21.5668 10
-      vertex -16.6815 -21.5668 3.5
+      vertex -11.3161 -21.2156 3.5
+      vertex -9.55065 -20.8644 3.5
+      vertex -9.75551 -20.1891 3.5
     endloop
   endfacet
-  facet normal -0.634394 0.77301 0
+  facet normal 0 0 1
+    outer loop
+      vertex -9.48148 -21.5668 3.5
+      vertex -11.2815 -21.5668 3.5
+      vertex -9.55065 -22.2691 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4185 -20.8779 3.5
+      vertex -9.75551 -20.1891 3.5
+      vertex -10.0882 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.3161 -21.9179 3.5
+      vertex -9.55065 -22.2691 3.5
+      vertex -11.2815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5848 -20.5667 3.5
+      vertex -10.0882 -19.5667 3.5
+      vertex -10.5359 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55065 -22.2691 3.5
+      vertex -11.3161 -21.9179 3.5
+      vertex -9.75551 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.8087 -20.294 3.5
+      vertex -10.5359 -19.0212 3.5
+      vertex -11.0814 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.4185 -22.2556 3.5
+      vertex -9.75551 -22.9444 3.5
+      vertex -11.3161 -21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 -22.9444 3.5
+      vertex -11.4185 -22.2556 3.5
+      vertex -10.0882 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55065 -20.8644 3.5
+      vertex -11.3161 -21.2156 3.5
+      vertex -11.2815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 -20.1891 3.5
+      vertex -11.4185 -20.8779 3.5
+      vertex -11.3161 -21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.0882 -19.5667 3.5
+      vertex -11.5848 -20.5667 3.5
+      vertex -11.4185 -20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0814 -20.0701 3.5
+      vertex -11.0814 -18.5735 3.5
+      vertex -11.7038 -18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 -19.0212 3.5
+      vertex -11.8087 -20.294 3.5
+      vertex -11.5848 -20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 -18.5735 3.5
+      vertex -12.0814 -20.0701 3.5
+      vertex -11.8087 -20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3926 -19.9038 3.5
+      vertex -11.7038 -18.2408 3.5
+      vertex -12.3792 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 -18.2408 3.5
+      vertex -12.3926 -19.9038 3.5
+      vertex -12.0814 -20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 -18.0359 3.5
+      vertex -12.7303 -19.8013 3.5
+      vertex -12.3926 -19.9038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 -17.9668 3.5
+      vertex -12.7303 -19.8013 3.5
+      vertex -12.3792 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 -17.9668 3.5
+      vertex -13.0815 -19.7668 3.5
+      vertex -12.7303 -19.8013 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 -17.9668 3.5
+      vertex -13.4326 -19.8013 3.5
+      vertex -13.0815 -19.7668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.7838 -18.0359 3.5
+      vertex -13.4326 -19.8013 3.5
+      vertex -13.0815 -17.9668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 -19.8013 3.5
+      vertex -13.7838 -18.0359 3.5
+      vertex -13.7703 -19.9038 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.4591 -18.2408 3.5
+      vertex -13.7703 -19.9038 3.5
+      vertex -13.7838 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7703 -19.9038 3.5
+      vertex -14.4591 -18.2408 3.5
+      vertex -14.0815 -20.0701 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.0815 -18.5735 3.5
+      vertex -14.0815 -20.0701 3.5
+      vertex -14.4591 -18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0815 -20.0701 3.5
+      vertex -15.0815 -18.5735 3.5
+      vertex -14.3543 -20.294 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6271 -19.0212 3.5
+      vertex -14.3543 -20.294 3.5
+      vertex -15.0815 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3543 -20.294 3.5
+      vertex -15.6271 -19.0212 3.5
+      vertex -14.5781 -20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5781 -20.5667 3.5
+      vertex -16.0748 -19.5667 3.5
+      vertex -14.7445 -20.8779 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.0748 -19.5667 3.5
+      vertex -14.5781 -20.5667 3.5
+      vertex -15.6271 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.5848 -22.5668 3.5
+      vertex -10.0882 -23.5668 3.5
+      vertex -11.4185 -22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.0882 -23.5668 3.5
+      vertex -11.5848 -22.5668 3.5
+      vertex -10.5359 -24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.8087 -22.8395 3.5
+      vertex -10.5359 -24.1123 3.5
+      vertex -11.5848 -22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
     outer loop
       vertex -10.5359 -24.1123 3.5
-      vertex -11.0814 -24.56 10
-      vertex -10.5359 -24.1123 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex -11.0814 -24.56 10
-      vertex -10.5359 -24.1123 3.5
+      vertex -11.8087 -22.8395 3.5
       vertex -11.0814 -24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.0814 -23.0634 3.5
+      vertex -11.0814 -24.56 3.5
+      vertex -11.8087 -22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 -24.56 3.5
+      vertex -12.0814 -23.0634 3.5
+      vertex -11.7038 -24.8927 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3926 -23.2297 3.5
+      vertex -11.7038 -24.8927 3.5
+      vertex -12.0814 -23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 -24.8927 3.5
+      vertex -12.3926 -23.2297 3.5
+      vertex -12.3792 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.7303 -23.3322 3.5
+      vertex -12.3792 -25.0976 3.5
+      vertex -12.3926 -23.2297 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0815 -23.3668 3.5
+      vertex -12.3792 -25.0976 3.5
+      vertex -12.7303 -23.3322 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 -23.3668 3.5
+      vertex -13.0815 -25.1668 3.5
+      vertex -12.3792 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 -23.3322 3.5
+      vertex -13.0815 -25.1668 3.5
+      vertex -13.0815 -23.3668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 -25.0976 3.5
+      vertex -13.4326 -23.3322 3.5
+      vertex -13.7703 -23.2297 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4326 -23.3322 3.5
+      vertex -13.7838 -25.0976 3.5
+      vertex -13.0815 -25.1668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 -24.8927 3.5
+      vertex -13.7703 -23.2297 3.5
+      vertex -14.0815 -23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 -24.56 3.5
+      vertex -14.0815 -23.0634 3.5
+      vertex -14.3543 -22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7703 -23.2297 3.5
+      vertex -14.4591 -24.8927 3.5
+      vertex -13.7838 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6271 -24.1123 3.5
+      vertex -14.3543 -22.8395 3.5
+      vertex -14.5781 -22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 -23.5668 3.5
+      vertex -14.5781 -22.5668 3.5
+      vertex -14.7445 -22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4074 -22.9444 3.5
+      vertex -14.7445 -22.2556 3.5
+      vertex -14.8469 -21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0815 -23.0634 3.5
+      vertex -15.0815 -24.56 3.5
+      vertex -14.4591 -24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 -22.2691 3.5
+      vertex -14.8469 -21.9179 3.5
+      vertex -14.8815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.4074 -20.1891 3.5
+      vertex -14.7445 -20.8779 3.5
+      vertex -16.0748 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7445 -20.8779 3.5
+      vertex -16.4074 -20.1891 3.5
+      vertex -14.8469 -21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3543 -22.8395 3.5
+      vertex -15.6271 -24.1123 3.5
+      vertex -15.0815 -24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.6123 -20.8644 3.5
+      vertex -14.8469 -21.2156 3.5
+      vertex -16.4074 -20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5781 -22.5668 3.5
+      vertex -16.0748 -23.5668 3.5
+      vertex -15.6271 -24.1123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8469 -21.2156 3.5
+      vertex -16.6123 -20.8644 3.5
+      vertex -14.8815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7445 -22.2556 3.5
+      vertex -16.4074 -22.9444 3.5
+      vertex -16.0748 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6815 -21.5668 3.5
+      vertex -14.8815 -21.5668 3.5
+      vertex -16.6123 -20.8644 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8469 -21.9179 3.5
+      vertex -16.6123 -22.2691 3.5
+      vertex -16.4074 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8815 -21.5668 3.5
+      vertex -16.6815 -21.5668 3.5
+      vertex -16.6123 -22.2691 3.5
     endloop
   endfacet
   facet normal -0.881921 0.471398 0
@@ -4731,6 +5193,34 @@ solid OpenSCAD_Model
       vertex -10.0882 -23.5668 10
     endloop
   endfacet
+  facet normal -0.773011 0.634393 0
+    outer loop
+      vertex -10.5359 -24.1123 3.5
+      vertex -10.0882 -23.5668 10
+      vertex -10.0882 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal -0.773011 0.634393 0
+    outer loop
+      vertex -10.0882 -23.5668 10
+      vertex -10.5359 -24.1123 3.5
+      vertex -10.5359 -24.1123 10
+    endloop
+  endfacet
+  facet normal 0.290284 -0.95694 0
+    outer loop
+      vertex -14.4591 -18.2408 3.5
+      vertex -13.7838 -18.0359 10
+      vertex -14.4591 -18.2408 10
+    endloop
+  endfacet
+  facet normal 0.290284 -0.95694 0
+    outer loop
+      vertex -13.7838 -18.0359 10
+      vertex -14.4591 -18.2408 3.5
+      vertex -13.7838 -18.0359 3.5
+    endloop
+  endfacet
   facet normal -0.995185 -0.0980169 0
     outer loop
       vertex -9.48148 -21.5668 3.5
@@ -4745,32 +5235,18 @@ solid OpenSCAD_Model
       vertex -9.48148 -21.5668 10
     endloop
   endfacet
-  facet normal 0.634394 0.77301 -0
+  facet normal 0.471397 -0.881921 0
     outer loop
-      vertex -15.0815 -24.56 3.5
-      vertex -15.6271 -24.1123 10
-      vertex -15.0815 -24.56 10
+      vertex -15.0815 -18.5735 3.5
+      vertex -14.4591 -18.2408 10
+      vertex -15.0815 -18.5735 10
     endloop
   endfacet
-  facet normal 0.634394 0.77301 0
+  facet normal 0.471397 -0.881921 0
     outer loop
-      vertex -15.6271 -24.1123 10
-      vertex -15.0815 -24.56 3.5
-      vertex -15.6271 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 0.290283 0
-    outer loop
-      vertex -9.75551 -22.9444 3.5
-      vertex -9.55065 -22.2691 10
-      vertex -9.55065 -22.2691 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 0.290283 0
-    outer loop
-      vertex -9.55065 -22.2691 10
-      vertex -9.75551 -22.9444 3.5
-      vertex -9.75551 -22.9444 10
+      vertex -14.4591 -18.2408 10
+      vertex -15.0815 -18.5735 3.5
+      vertex -14.4591 -18.2408 3.5
     endloop
   endfacet
   facet normal 0.634394 -0.77301 0
@@ -4787,20 +5263,6 @@ solid OpenSCAD_Model
       vertex -15.0815 -18.5735 3.5
     endloop
   endfacet
-  facet normal 0.290284 -0.95694 0
-    outer loop
-      vertex -14.4591 -18.2408 3.5
-      vertex -13.7838 -18.0359 10
-      vertex -14.4591 -18.2408 10
-    endloop
-  endfacet
-  facet normal 0.290284 -0.95694 0
-    outer loop
-      vertex -13.7838 -18.0359 10
-      vertex -14.4591 -18.2408 3.5
-      vertex -13.7838 -18.0359 3.5
-    endloop
-  endfacet
   facet normal -0.956941 -0.290284 0
     outer loop
       vertex -9.55065 -20.8644 3.5
@@ -4815,494 +5277,18 @@ solid OpenSCAD_Model
       vertex -9.55065 -20.8644 10
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 0
+  facet normal -0.881921 -0.471397 0
     outer loop
-      vertex -11.0814 -18.5735 3.5
-      vertex -10.5359 -19.0212 10
-      vertex -11.0814 -18.5735 10
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 -0
-    outer loop
-      vertex -10.5359 -19.0212 10
-      vertex -11.0814 -18.5735 3.5
-      vertex -10.5359 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex -10.0882 -19.5667 3.5
-      vertex -10.5359 -19.0212 10
-      vertex -10.5359 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex -10.5359 -19.0212 10
-      vertex -10.0882 -19.5667 3.5
+      vertex -9.75551 -20.1891 3.5
       vertex -10.0882 -19.5667 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.2815 -21.5668 3.5
-      vertex -9.48148 -21.5668 3.5
-      vertex -9.55065 -20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.3161 -21.2156 3.5
-      vertex -9.55065 -20.8644 3.5
-      vertex -9.75551 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.48148 -21.5668 3.5
-      vertex -11.2815 -21.5668 3.5
-      vertex -9.55065 -22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.4185 -20.8779 3.5
-      vertex -9.75551 -20.1891 3.5
       vertex -10.0882 -19.5667 3.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.881921 -0.471397 0
     outer loop
-      vertex -11.3161 -21.9179 3.5
-      vertex -9.55065 -22.2691 3.5
-      vertex -11.2815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5848 -20.5667 3.5
-      vertex -10.0882 -19.5667 3.5
-      vertex -10.5359 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.55065 -22.2691 3.5
-      vertex -11.3161 -21.9179 3.5
-      vertex -9.75551 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.8087 -20.294 3.5
-      vertex -10.5359 -19.0212 3.5
-      vertex -11.0814 -18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.4185 -22.2556 3.5
-      vertex -9.75551 -22.9444 3.5
-      vertex -11.3161 -21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.75551 -22.9444 3.5
-      vertex -11.4185 -22.2556 3.5
-      vertex -10.0882 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.55065 -20.8644 3.5
-      vertex -11.3161 -21.2156 3.5
-      vertex -11.2815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
+      vertex -10.0882 -19.5667 10
       vertex -9.75551 -20.1891 3.5
-      vertex -11.4185 -20.8779 3.5
-      vertex -11.3161 -21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.0882 -19.5667 3.5
-      vertex -11.5848 -20.5667 3.5
-      vertex -11.4185 -20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0814 -20.0701 3.5
-      vertex -11.0814 -18.5735 3.5
-      vertex -11.7038 -18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 -19.0212 3.5
-      vertex -11.8087 -20.294 3.5
-      vertex -11.5848 -20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 -18.5735 3.5
-      vertex -12.0814 -20.0701 3.5
-      vertex -11.8087 -20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3926 -19.9038 3.5
-      vertex -11.7038 -18.2408 3.5
-      vertex -12.3792 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 -18.2408 3.5
-      vertex -12.3926 -19.9038 3.5
-      vertex -12.0814 -20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 -18.0359 3.5
-      vertex -12.7303 -19.8013 3.5
-      vertex -12.3926 -19.9038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 -17.9668 3.5
-      vertex -12.7303 -19.8013 3.5
-      vertex -12.3792 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 -17.9668 3.5
-      vertex -13.0815 -19.7668 3.5
-      vertex -12.7303 -19.8013 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 -17.9668 3.5
-      vertex -13.4326 -19.8013 3.5
-      vertex -13.0815 -19.7668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.7838 -18.0359 3.5
-      vertex -13.4326 -19.8013 3.5
-      vertex -13.0815 -17.9668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 -19.8013 3.5
-      vertex -13.7838 -18.0359 3.5
-      vertex -13.7703 -19.9038 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.4591 -18.2408 3.5
-      vertex -13.7703 -19.9038 3.5
-      vertex -13.7838 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7703 -19.9038 3.5
-      vertex -14.4591 -18.2408 3.5
-      vertex -14.0815 -20.0701 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.0815 -18.5735 3.5
-      vertex -14.0815 -20.0701 3.5
-      vertex -14.4591 -18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0815 -20.0701 3.5
-      vertex -15.0815 -18.5735 3.5
-      vertex -14.3543 -20.294 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.6271 -19.0212 3.5
-      vertex -14.3543 -20.294 3.5
-      vertex -15.0815 -18.5735 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3543 -20.294 3.5
-      vertex -15.6271 -19.0212 3.5
-      vertex -14.5781 -20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5781 -20.5667 3.5
-      vertex -16.0748 -19.5667 3.5
-      vertex -14.7445 -20.8779 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.0748 -19.5667 3.5
-      vertex -14.5781 -20.5667 3.5
-      vertex -15.6271 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.5848 -22.5668 3.5
-      vertex -10.0882 -23.5668 3.5
-      vertex -11.4185 -22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.0882 -23.5668 3.5
-      vertex -11.5848 -22.5668 3.5
-      vertex -10.5359 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.8087 -22.8395 3.5
-      vertex -10.5359 -24.1123 3.5
-      vertex -11.5848 -22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 -24.1123 3.5
-      vertex -11.8087 -22.8395 3.5
-      vertex -11.0814 -24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.0814 -23.0634 3.5
-      vertex -11.0814 -24.56 3.5
-      vertex -11.8087 -22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 -24.56 3.5
-      vertex -12.0814 -23.0634 3.5
-      vertex -11.7038 -24.8927 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.3926 -23.2297 3.5
-      vertex -11.7038 -24.8927 3.5
-      vertex -12.0814 -23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 -24.8927 3.5
-      vertex -12.3926 -23.2297 3.5
-      vertex -12.3792 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.7303 -23.3322 3.5
-      vertex -12.3792 -25.0976 3.5
-      vertex -12.3926 -23.2297 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.0815 -23.3668 3.5
-      vertex -12.3792 -25.0976 3.5
-      vertex -12.7303 -23.3322 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0815 -23.3668 3.5
-      vertex -13.0815 -25.1668 3.5
-      vertex -12.3792 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 -23.3322 3.5
-      vertex -13.0815 -25.1668 3.5
-      vertex -13.0815 -23.3668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7838 -25.0976 3.5
-      vertex -13.4326 -23.3322 3.5
-      vertex -13.7703 -23.2297 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4326 -23.3322 3.5
-      vertex -13.7838 -25.0976 3.5
-      vertex -13.0815 -25.1668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4591 -24.8927 3.5
-      vertex -13.7703 -23.2297 3.5
-      vertex -14.0815 -23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0815 -24.56 3.5
-      vertex -14.0815 -23.0634 3.5
-      vertex -14.3543 -22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7703 -23.2297 3.5
-      vertex -14.4591 -24.8927 3.5
-      vertex -13.7838 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6271 -24.1123 3.5
-      vertex -14.3543 -22.8395 3.5
-      vertex -14.5781 -22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 -23.5668 3.5
-      vertex -14.5781 -22.5668 3.5
-      vertex -14.7445 -22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 -22.9444 3.5
-      vertex -14.7445 -22.2556 3.5
-      vertex -14.8469 -21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0815 -23.0634 3.5
-      vertex -15.0815 -24.56 3.5
-      vertex -14.4591 -24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 -22.2691 3.5
-      vertex -14.8469 -21.9179 3.5
-      vertex -14.8815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.4074 -20.1891 3.5
-      vertex -14.7445 -20.8779 3.5
-      vertex -16.0748 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7445 -20.8779 3.5
-      vertex -16.4074 -20.1891 3.5
-      vertex -14.8469 -21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3543 -22.8395 3.5
-      vertex -15.6271 -24.1123 3.5
-      vertex -15.0815 -24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.6123 -20.8644 3.5
-      vertex -14.8469 -21.2156 3.5
-      vertex -16.4074 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5781 -22.5668 3.5
-      vertex -16.0748 -23.5668 3.5
-      vertex -15.6271 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8469 -21.2156 3.5
-      vertex -16.6123 -20.8644 3.5
-      vertex -14.8815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7445 -22.2556 3.5
-      vertex -16.4074 -22.9444 3.5
-      vertex -16.0748 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6815 -21.5668 3.5
-      vertex -14.8815 -21.5668 3.5
-      vertex -16.6123 -20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8469 -21.9179 3.5
-      vertex -16.6123 -22.2691 3.5
-      vertex -16.4074 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8815 -21.5668 3.5
-      vertex -16.6815 -21.5668 3.5
-      vertex -16.6123 -22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex -15.0815 -18.5735 3.5
-      vertex -14.4591 -18.2408 10
-      vertex -15.0815 -18.5735 10
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex -14.4591 -18.2408 10
-      vertex -15.0815 -18.5735 3.5
-      vertex -14.4591 -18.2408 3.5
+      vertex -9.75551 -20.1891 10
     endloop
   endfacet
   facet normal -0.995185 0.0980171 0
@@ -5345,6 +5331,20 @@ solid OpenSCAD_Model
       vertex -11.0814 -18.5735 10
       vertex -11.7038 -18.2408 3.5
       vertex -11.0814 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 0
+    outer loop
+      vertex -11.0814 -18.5735 3.5
+      vertex -10.5359 -19.0212 10
+      vertex -11.0814 -18.5735 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 -0
+    outer loop
+      vertex -10.5359 -19.0212 10
+      vertex -11.0814 -18.5735 3.5
+      vertex -10.5359 -19.0212 3.5
     endloop
   endfacet
   facet normal 0.0980157 -0.995185 0
@@ -5823,18 +5823,18 @@ solid OpenSCAD_Model
       vertex 12.7303 -19.8013 0
     endloop
   endfacet
-  facet normal 0.290285 0.95694 -0
+  facet normal 0.634394 0.77301 -0
     outer loop
-      vertex 12.3792 -25.0976 3.5
-      vertex 11.7038 -24.8927 10
-      vertex 12.3792 -25.0976 10
+      vertex 11.0814 -24.56 3.5
+      vertex 10.5359 -24.1123 10
+      vertex 11.0814 -24.56 10
     endloop
   endfacet
-  facet normal 0.290285 0.95694 0
+  facet normal 0.634394 0.77301 0
     outer loop
-      vertex 11.7038 -24.8927 10
-      vertex 12.3792 -25.0976 3.5
-      vertex 11.7038 -24.8927 3.5
+      vertex 10.5359 -24.1123 10
+      vertex 11.0814 -24.56 3.5
+      vertex 10.5359 -24.1123 3.5
     endloop
   endfacet
   facet normal -0.773009 -0.634395 0
@@ -5849,6 +5849,118 @@ solid OpenSCAD_Model
       vertex 15.6271 -19.0212 10
       vertex 16.0748 -19.5667 3.5
       vertex 16.0748 -19.5667 10
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex 15.6271 -24.1123 3.5
+      vertex 16.0748 -23.5668 10
+      vertex 16.0748 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex 16.0748 -23.5668 10
+      vertex 15.6271 -24.1123 3.5
+      vertex 15.6271 -24.1123 10
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex 10.0882 -19.5667 10
+      vertex 10.5359 -19.0212 3.5
+      vertex 10.5359 -19.0212 10
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex 10.5359 -19.0212 3.5
+      vertex 10.0882 -19.5667 10
+      vertex 10.0882 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal -0.0980157 0.995185 0
+    outer loop
+      vertex 13.7838 -25.0976 3.5
+      vertex 13.0815 -25.1668 10
+      vertex 13.7838 -25.0976 10
+    endloop
+  endfacet
+  facet normal -0.0980157 0.995185 0
+    outer loop
+      vertex 13.0815 -25.1668 10
+      vertex 13.7838 -25.0976 3.5
+      vertex 13.0815 -25.1668 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980182 0
+    outer loop
+      vertex 16.6815 -21.5668 3.5
+      vertex 16.6123 -20.8644 10
+      vertex 16.6123 -20.8644 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980182 0
+    outer loop
+      vertex 16.6123 -20.8644 10
+      vertex 16.6815 -21.5668 3.5
+      vertex 16.6815 -21.5668 10
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex 16.4074 -22.9444 3.5
+      vertex 16.6123 -22.2691 10
+      vertex 16.6123 -22.2691 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex 16.6123 -22.2691 10
+      vertex 16.4074 -22.9444 3.5
+      vertex 16.4074 -22.9444 10
+    endloop
+  endfacet
+  facet normal 0.956941 0.290283 0
+    outer loop
+      vertex 9.75551 -22.9444 10
+      vertex 9.55065 -22.2691 3.5
+      vertex 9.55065 -22.2691 10
+    endloop
+  endfacet
+  facet normal 0.956941 0.290283 0
+    outer loop
+      vertex 9.55065 -22.2691 3.5
+      vertex 9.75551 -22.9444 10
+      vertex 9.75551 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0.290285 0.95694 -0
+    outer loop
+      vertex 12.3792 -25.0976 3.5
+      vertex 11.7038 -24.8927 10
+      vertex 12.3792 -25.0976 10
+    endloop
+  endfacet
+  facet normal 0.290285 0.95694 0
+    outer loop
+      vertex 11.7038 -24.8927 10
+      vertex 12.3792 -25.0976 3.5
+      vertex 11.7038 -24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0.471397 0.881921 -0
+    outer loop
+      vertex 11.7038 -24.8927 3.5
+      vertex 11.0814 -24.56 10
+      vertex 11.7038 -24.8927 10
+    endloop
+  endfacet
+  facet normal 0.471397 0.881921 0
+    outer loop
+      vertex 11.0814 -24.56 10
+      vertex 11.7038 -24.8927 3.5
+      vertex 11.0814 -24.56 3.5
     endloop
   endfacet
   facet normal 0.0980157 0.995185 -0
@@ -5879,102 +5991,18 @@ solid OpenSCAD_Model
       vertex 14.4591 -24.8927 3.5
     endloop
   endfacet
-  facet normal -0.956941 0.290284 0
-    outer loop
-      vertex 16.4074 -22.9444 3.5
-      vertex 16.6123 -22.2691 10
-      vertex 16.6123 -22.2691 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 0.290284 0
-    outer loop
-      vertex 16.6123 -22.2691 10
-      vertex 16.4074 -22.9444 3.5
-      vertex 16.4074 -22.9444 10
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471395 0
-    outer loop
-      vertex 16.4074 -20.1891 3.5
-      vertex 16.0748 -19.5667 10
-      vertex 16.0748 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471395 0
-    outer loop
-      vertex 16.0748 -19.5667 10
-      vertex 16.4074 -20.1891 3.5
-      vertex 16.4074 -20.1891 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 10.5359 -24.1123 10
-      vertex 10.0882 -23.5668 3.5
-      vertex 10.0882 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 10.0882 -23.5668 3.5
-      vertex 10.5359 -24.1123 10
-      vertex 10.5359 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex 9.75551 -20.1891 10
-      vertex 10.0882 -19.5667 3.5
-      vertex 10.0882 -19.5667 10
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex 10.0882 -19.5667 3.5
-      vertex 9.75551 -20.1891 10
-      vertex 9.75551 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0.471397 0.881921 -0
-    outer loop
-      vertex 11.7038 -24.8927 3.5
-      vertex 11.0814 -24.56 10
-      vertex 11.7038 -24.8927 10
-    endloop
-  endfacet
-  facet normal 0.471397 0.881921 0
-    outer loop
-      vertex 11.0814 -24.56 10
-      vertex 11.7038 -24.8927 3.5
-      vertex 11.0814 -24.56 3.5
-    endloop
-  endfacet
-  facet normal -0.0980157 0.995185 0
-    outer loop
-      vertex 13.7838 -25.0976 3.5
-      vertex 13.0815 -25.1668 10
-      vertex 13.7838 -25.0976 10
-    endloop
-  endfacet
-  facet normal -0.0980157 0.995185 0
-    outer loop
-      vertex 13.0815 -25.1668 10
-      vertex 13.7838 -25.0976 3.5
-      vertex 13.0815 -25.1668 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
+  facet normal -0.634394 0.77301 0
     outer loop
       vertex 15.6271 -24.1123 3.5
-      vertex 16.0748 -23.5668 10
-      vertex 16.0748 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex 16.0748 -23.5668 10
-      vertex 15.6271 -24.1123 3.5
+      vertex 15.0815 -24.56 10
       vertex 15.6271 -24.1123 10
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex 15.0815 -24.56 10
+      vertex 15.6271 -24.1123 3.5
+      vertex 15.0815 -24.56 3.5
     endloop
   endfacet
   facet normal -0.290284 0.95694 0
@@ -6005,6 +6033,20 @@ solid OpenSCAD_Model
       vertex 16.6123 -20.8644 10
     endloop
   endfacet
+  facet normal -0.881922 -0.471395 0
+    outer loop
+      vertex 16.4074 -20.1891 3.5
+      vertex 16.0748 -19.5667 10
+      vertex 16.0748 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal -0.881922 -0.471395 0
+    outer loop
+      vertex 16.0748 -19.5667 10
+      vertex 16.4074 -20.1891 3.5
+      vertex 16.4074 -20.1891 10
+    endloop
+  endfacet
   facet normal -0.995185 0.0980185 0
     outer loop
       vertex 16.6123 -22.2691 3.5
@@ -6033,32 +6075,452 @@ solid OpenSCAD_Model
       vertex 16.0748 -23.5668 10
     endloop
   endfacet
-  facet normal -0.995185 -0.0980182 0
+  facet normal 0 0 1
     outer loop
+      vertex 14.8815 -21.5668 3.5
       vertex 16.6815 -21.5668 3.5
-      vertex 16.6123 -20.8644 10
       vertex 16.6123 -20.8644 3.5
     endloop
   endfacet
-  facet normal -0.995185 -0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex 16.6123 -20.8644 10
+      vertex 14.8469 -21.2156 3.5
+      vertex 16.6123 -20.8644 3.5
+      vertex 16.4074 -20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex 16.6815 -21.5668 3.5
-      vertex 16.6815 -21.5668 10
+      vertex 14.8815 -21.5668 3.5
+      vertex 16.6123 -22.2691 3.5
     endloop
   endfacet
-  facet normal 0.634394 0.77301 -0
+  facet normal 0 0 1
     outer loop
-      vertex 11.0814 -24.56 3.5
-      vertex 10.5359 -24.1123 10
-      vertex 11.0814 -24.56 10
+      vertex 14.7445 -20.8779 3.5
+      vertex 16.4074 -20.1891 3.5
+      vertex 16.0748 -19.5667 3.5
     endloop
   endfacet
-  facet normal 0.634394 0.77301 0
+  facet normal -0 0 1
     outer loop
-      vertex 10.5359 -24.1123 10
+      vertex 14.8469 -21.9179 3.5
+      vertex 16.6123 -22.2691 3.5
+      vertex 14.8815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5781 -20.5667 3.5
+      vertex 16.0748 -19.5667 3.5
+      vertex 15.6271 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -22.2691 3.5
+      vertex 14.8469 -21.9179 3.5
+      vertex 16.4074 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3543 -20.294 3.5
+      vertex 15.6271 -19.0212 3.5
+      vertex 15.0815 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.7445 -22.2556 3.5
+      vertex 16.4074 -22.9444 3.5
+      vertex 14.8469 -21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 -22.9444 3.5
+      vertex 14.7445 -22.2556 3.5
+      vertex 16.0748 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -20.8644 3.5
+      vertex 14.8469 -21.2156 3.5
+      vertex 14.8815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 -20.1891 3.5
+      vertex 14.7445 -20.8779 3.5
+      vertex 14.8469 -21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 -19.5667 3.5
+      vertex 14.5781 -20.5667 3.5
+      vertex 14.7445 -20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0815 -20.0701 3.5
+      vertex 15.0815 -18.5735 3.5
+      vertex 14.4591 -18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 -19.0212 3.5
+      vertex 14.3543 -20.294 3.5
+      vertex 14.5781 -20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 -18.5735 3.5
+      vertex 14.0815 -20.0701 3.5
+      vertex 14.3543 -20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7703 -19.9038 3.5
+      vertex 14.4591 -18.2408 3.5
+      vertex 13.7838 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 -18.2408 3.5
+      vertex 13.7703 -19.9038 3.5
+      vertex 14.0815 -20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7838 -18.0359 3.5
+      vertex 13.4326 -19.8013 3.5
+      vertex 13.7703 -19.9038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 -17.9668 3.5
+      vertex 13.4326 -19.8013 3.5
+      vertex 13.7838 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 -17.9668 3.5
+      vertex 13.0815 -19.7668 3.5
+      vertex 13.4326 -19.8013 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 -17.9668 3.5
+      vertex 12.7303 -19.8013 3.5
+      vertex 13.0815 -19.7668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.3792 -18.0359 3.5
+      vertex 12.7303 -19.8013 3.5
+      vertex 13.0815 -17.9668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 -19.8013 3.5
+      vertex 12.3792 -18.0359 3.5
+      vertex 12.3926 -19.9038 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7038 -18.2408 3.5
+      vertex 12.3926 -19.9038 3.5
+      vertex 12.3792 -18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3926 -19.9038 3.5
+      vertex 11.7038 -18.2408 3.5
+      vertex 12.0814 -20.0701 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.0814 -18.5735 3.5
+      vertex 12.0814 -20.0701 3.5
+      vertex 11.7038 -18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0814 -20.0701 3.5
+      vertex 11.0814 -18.5735 3.5
+      vertex 11.8087 -20.294 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.5359 -19.0212 3.5
+      vertex 11.8087 -20.294 3.5
+      vertex 11.0814 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.8087 -20.294 3.5
+      vertex 10.5359 -19.0212 3.5
+      vertex 11.5848 -20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5848 -20.5667 3.5
+      vertex 10.0882 -19.5667 3.5
+      vertex 11.4185 -20.8779 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.0882 -19.5667 3.5
+      vertex 11.5848 -20.5667 3.5
+      vertex 10.5359 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5781 -22.5668 3.5
+      vertex 16.0748 -23.5668 3.5
+      vertex 14.7445 -22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 -23.5668 3.5
+      vertex 14.5781 -22.5668 3.5
+      vertex 15.6271 -24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.3543 -22.8395 3.5
+      vertex 15.6271 -24.1123 3.5
+      vertex 14.5781 -22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 -24.1123 3.5
+      vertex 14.3543 -22.8395 3.5
+      vertex 15.0815 -24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.0815 -23.0634 3.5
+      vertex 15.0815 -24.56 3.5
+      vertex 14.3543 -22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 -24.56 3.5
+      vertex 14.0815 -23.0634 3.5
+      vertex 14.4591 -24.8927 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.7703 -23.2297 3.5
+      vertex 14.4591 -24.8927 3.5
+      vertex 14.0815 -23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 -24.8927 3.5
+      vertex 13.7703 -23.2297 3.5
+      vertex 13.7838 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.4326 -23.3322 3.5
+      vertex 13.7838 -25.0976 3.5
+      vertex 13.7703 -23.2297 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0815 -23.3668 3.5
+      vertex 13.7838 -25.0976 3.5
+      vertex 13.4326 -23.3322 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 -23.3668 3.5
+      vertex 13.0815 -25.1668 3.5
+      vertex 13.7838 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 -23.3322 3.5
+      vertex 13.0815 -25.1668 3.5
+      vertex 13.0815 -23.3668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 -25.0976 3.5
+      vertex 12.7303 -23.3322 3.5
+      vertex 12.3926 -23.2297 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 -23.3322 3.5
+      vertex 12.3792 -25.0976 3.5
+      vertex 13.0815 -25.1668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7038 -24.8927 3.5
+      vertex 12.3926 -23.2297 3.5
+      vertex 12.0814 -23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex 11.0814 -24.56 3.5
+      vertex 12.0814 -23.0634 3.5
+      vertex 11.8087 -22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3926 -23.2297 3.5
+      vertex 11.7038 -24.8927 3.5
+      vertex 12.3792 -25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex 10.5359 -24.1123 3.5
+      vertex 11.8087 -22.8395 3.5
+      vertex 11.5848 -22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0882 -23.5668 3.5
+      vertex 11.5848 -22.5668 3.5
+      vertex 11.4185 -22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 -22.9444 3.5
+      vertex 11.4185 -22.2556 3.5
+      vertex 11.3161 -21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0814 -23.0634 3.5
+      vertex 11.0814 -24.56 3.5
+      vertex 11.7038 -24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.55065 -22.2691 3.5
+      vertex 11.3161 -21.9179 3.5
+      vertex 11.2815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.75551 -20.1891 3.5
+      vertex 11.4185 -20.8779 3.5
+      vertex 10.0882 -19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4185 -20.8779 3.5
+      vertex 9.75551 -20.1891 3.5
+      vertex 11.3161 -21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.8087 -22.8395 3.5
+      vertex 10.5359 -24.1123 3.5
+      vertex 11.0814 -24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.55065 -20.8644 3.5
+      vertex 11.3161 -21.2156 3.5
+      vertex 9.75551 -20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5848 -22.5668 3.5
+      vertex 10.0882 -23.5668 3.5
+      vertex 10.5359 -24.1123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3161 -21.2156 3.5
+      vertex 9.55065 -20.8644 3.5
+      vertex 11.2815 -21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4185 -22.2556 3.5
+      vertex 9.75551 -22.9444 3.5
+      vertex 10.0882 -23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.48148 -21.5668 3.5
+      vertex 11.2815 -21.5668 3.5
+      vertex 9.55065 -20.8644 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3161 -21.9179 3.5
+      vertex 9.55065 -22.2691 3.5
+      vertex 9.75551 -22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2815 -21.5668 3.5
+      vertex 9.48148 -21.5668 3.5
+      vertex 9.55065 -22.2691 3.5
     endloop
   endfacet
   facet normal 0.881921 0.471398 0
@@ -6075,60 +6537,18 @@ solid OpenSCAD_Model
       vertex 10.0882 -23.5668 3.5
     endloop
   endfacet
-  facet normal 0.995185 -0.0980169 0
+  facet normal 0.773011 0.634393 0
     outer loop
-      vertex 9.48148 -21.5668 10
-      vertex 9.55065 -20.8644 3.5
-      vertex 9.55065 -20.8644 10
+      vertex 10.5359 -24.1123 10
+      vertex 10.0882 -23.5668 3.5
+      vertex 10.0882 -23.5668 10
     endloop
   endfacet
-  facet normal 0.995185 -0.0980169 0
+  facet normal 0.773011 0.634393 0
     outer loop
-      vertex 9.55065 -20.8644 3.5
-      vertex 9.48148 -21.5668 10
-      vertex 9.48148 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex 15.6271 -24.1123 3.5
-      vertex 15.0815 -24.56 10
-      vertex 15.6271 -24.1123 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex 15.0815 -24.56 10
-      vertex 15.6271 -24.1123 3.5
-      vertex 15.0815 -24.56 3.5
-    endloop
-  endfacet
-  facet normal 0.956941 0.290283 0
-    outer loop
-      vertex 9.75551 -22.9444 10
-      vertex 9.55065 -22.2691 3.5
-      vertex 9.55065 -22.2691 10
-    endloop
-  endfacet
-  facet normal 0.956941 0.290283 0
-    outer loop
-      vertex 9.55065 -22.2691 3.5
-      vertex 9.75551 -22.9444 10
-      vertex 9.75551 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 0
-    outer loop
-      vertex 15.0815 -18.5735 3.5
-      vertex 15.6271 -19.0212 10
-      vertex 15.0815 -18.5735 10
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 -0
-    outer loop
-      vertex 15.6271 -19.0212 10
-      vertex 15.0815 -18.5735 3.5
-      vertex 15.6271 -19.0212 3.5
+      vertex 10.0882 -23.5668 3.5
+      vertex 10.5359 -24.1123 10
+      vertex 10.5359 -24.1123 3.5
     endloop
   endfacet
   facet normal -0.290284 -0.95694 0
@@ -6145,494 +6565,18 @@ solid OpenSCAD_Model
       vertex 14.4591 -18.2408 3.5
     endloop
   endfacet
-  facet normal 0.956941 -0.290284 0
+  facet normal 0.995185 -0.0980169 0
     outer loop
+      vertex 9.48148 -21.5668 10
+      vertex 9.55065 -20.8644 3.5
       vertex 9.55065 -20.8644 10
-      vertex 9.75551 -20.1891 3.5
-      vertex 9.75551 -20.1891 10
     endloop
   endfacet
-  facet normal 0.956941 -0.290284 0
-    outer loop
-      vertex 9.75551 -20.1891 3.5
-      vertex 9.55065 -20.8644 10
-      vertex 9.55065 -20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex 10.5359 -19.0212 3.5
-      vertex 11.0814 -18.5735 10
-      vertex 10.5359 -19.0212 10
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex 11.0814 -18.5735 10
-      vertex 10.5359 -19.0212 3.5
-      vertex 11.0814 -18.5735 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex 10.0882 -19.5667 10
-      vertex 10.5359 -19.0212 3.5
-      vertex 10.5359 -19.0212 10
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex 10.5359 -19.0212 3.5
-      vertex 10.0882 -19.5667 10
-      vertex 10.0882 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8815 -21.5668 3.5
-      vertex 16.6815 -21.5668 3.5
-      vertex 16.6123 -20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8469 -21.2156 3.5
-      vertex 16.6123 -20.8644 3.5
-      vertex 16.4074 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6815 -21.5668 3.5
-      vertex 14.8815 -21.5668 3.5
-      vertex 16.6123 -22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7445 -20.8779 3.5
-      vertex 16.4074 -20.1891 3.5
-      vertex 16.0748 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.8469 -21.9179 3.5
-      vertex 16.6123 -22.2691 3.5
-      vertex 14.8815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5781 -20.5667 3.5
-      vertex 16.0748 -19.5667 3.5
-      vertex 15.6271 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -22.2691 3.5
-      vertex 14.8469 -21.9179 3.5
-      vertex 16.4074 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3543 -20.294 3.5
-      vertex 15.6271 -19.0212 3.5
-      vertex 15.0815 -18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.7445 -22.2556 3.5
-      vertex 16.4074 -22.9444 3.5
-      vertex 14.8469 -21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 -22.9444 3.5
-      vertex 14.7445 -22.2556 3.5
-      vertex 16.0748 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -20.8644 3.5
-      vertex 14.8469 -21.2156 3.5
-      vertex 14.8815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 -20.1891 3.5
-      vertex 14.7445 -20.8779 3.5
-      vertex 14.8469 -21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 -19.5667 3.5
-      vertex 14.5781 -20.5667 3.5
-      vertex 14.7445 -20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0815 -20.0701 3.5
-      vertex 15.0815 -18.5735 3.5
-      vertex 14.4591 -18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 -19.0212 3.5
-      vertex 14.3543 -20.294 3.5
-      vertex 14.5781 -20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 -18.5735 3.5
-      vertex 14.0815 -20.0701 3.5
-      vertex 14.3543 -20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7703 -19.9038 3.5
-      vertex 14.4591 -18.2408 3.5
-      vertex 13.7838 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 -18.2408 3.5
-      vertex 13.7703 -19.9038 3.5
-      vertex 14.0815 -20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7838 -18.0359 3.5
-      vertex 13.4326 -19.8013 3.5
-      vertex 13.7703 -19.9038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 -17.9668 3.5
-      vertex 13.4326 -19.8013 3.5
-      vertex 13.7838 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 -17.9668 3.5
-      vertex 13.0815 -19.7668 3.5
-      vertex 13.4326 -19.8013 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 -17.9668 3.5
-      vertex 12.7303 -19.8013 3.5
-      vertex 13.0815 -19.7668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.3792 -18.0359 3.5
-      vertex 12.7303 -19.8013 3.5
-      vertex 13.0815 -17.9668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 -19.8013 3.5
-      vertex 12.3792 -18.0359 3.5
-      vertex 12.3926 -19.9038 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7038 -18.2408 3.5
-      vertex 12.3926 -19.9038 3.5
-      vertex 12.3792 -18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3926 -19.9038 3.5
-      vertex 11.7038 -18.2408 3.5
-      vertex 12.0814 -20.0701 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.0814 -18.5735 3.5
-      vertex 12.0814 -20.0701 3.5
-      vertex 11.7038 -18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0814 -20.0701 3.5
-      vertex 11.0814 -18.5735 3.5
-      vertex 11.8087 -20.294 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.5359 -19.0212 3.5
-      vertex 11.8087 -20.294 3.5
-      vertex 11.0814 -18.5735 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8087 -20.294 3.5
-      vertex 10.5359 -19.0212 3.5
-      vertex 11.5848 -20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5848 -20.5667 3.5
-      vertex 10.0882 -19.5667 3.5
-      vertex 11.4185 -20.8779 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.0882 -19.5667 3.5
-      vertex 11.5848 -20.5667 3.5
-      vertex 10.5359 -19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.5781 -22.5668 3.5
-      vertex 16.0748 -23.5668 3.5
-      vertex 14.7445 -22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 -23.5668 3.5
-      vertex 14.5781 -22.5668 3.5
-      vertex 15.6271 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.3543 -22.8395 3.5
-      vertex 15.6271 -24.1123 3.5
-      vertex 14.5781 -22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 -24.1123 3.5
-      vertex 14.3543 -22.8395 3.5
-      vertex 15.0815 -24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.0815 -23.0634 3.5
-      vertex 15.0815 -24.56 3.5
-      vertex 14.3543 -22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 -24.56 3.5
-      vertex 14.0815 -23.0634 3.5
-      vertex 14.4591 -24.8927 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7703 -23.2297 3.5
-      vertex 14.4591 -24.8927 3.5
-      vertex 14.0815 -23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 -24.8927 3.5
-      vertex 13.7703 -23.2297 3.5
-      vertex 13.7838 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.4326 -23.3322 3.5
-      vertex 13.7838 -25.0976 3.5
-      vertex 13.7703 -23.2297 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0815 -23.3668 3.5
-      vertex 13.7838 -25.0976 3.5
-      vertex 13.4326 -23.3322 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 -23.3668 3.5
-      vertex 13.0815 -25.1668 3.5
-      vertex 13.7838 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 -23.3322 3.5
-      vertex 13.0815 -25.1668 3.5
-      vertex 13.0815 -23.3668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 -25.0976 3.5
-      vertex 12.7303 -23.3322 3.5
-      vertex 12.3926 -23.2297 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 -23.3322 3.5
-      vertex 12.3792 -25.0976 3.5
-      vertex 13.0815 -25.1668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7038 -24.8927 3.5
-      vertex 12.3926 -23.2297 3.5
-      vertex 12.0814 -23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.0814 -24.56 3.5
-      vertex 12.0814 -23.0634 3.5
-      vertex 11.8087 -22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3926 -23.2297 3.5
-      vertex 11.7038 -24.8927 3.5
-      vertex 12.3792 -25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5359 -24.1123 3.5
-      vertex 11.8087 -22.8395 3.5
-      vertex 11.5848 -22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.0882 -23.5668 3.5
-      vertex 11.5848 -22.5668 3.5
-      vertex 11.4185 -22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.75551 -22.9444 3.5
-      vertex 11.4185 -22.2556 3.5
-      vertex 11.3161 -21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0814 -23.0634 3.5
-      vertex 11.0814 -24.56 3.5
-      vertex 11.7038 -24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.55065 -22.2691 3.5
-      vertex 11.3161 -21.9179 3.5
-      vertex 11.2815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.75551 -20.1891 3.5
-      vertex 11.4185 -20.8779 3.5
-      vertex 10.0882 -19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.4185 -20.8779 3.5
-      vertex 9.75551 -20.1891 3.5
-      vertex 11.3161 -21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8087 -22.8395 3.5
-      vertex 10.5359 -24.1123 3.5
-      vertex 11.0814 -24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
+  facet normal 0.995185 -0.0980169 0
     outer loop
       vertex 9.55065 -20.8644 3.5
-      vertex 11.3161 -21.2156 3.5
-      vertex 9.75551 -20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5848 -22.5668 3.5
-      vertex 10.0882 -23.5668 3.5
-      vertex 10.5359 -24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.3161 -21.2156 3.5
-      vertex 9.55065 -20.8644 3.5
-      vertex 11.2815 -21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.4185 -22.2556 3.5
-      vertex 9.75551 -22.9444 3.5
-      vertex 10.0882 -23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
+      vertex 9.48148 -21.5668 10
       vertex 9.48148 -21.5668 3.5
-      vertex 11.2815 -21.5668 3.5
-      vertex 9.55065 -20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.3161 -21.9179 3.5
-      vertex 9.55065 -22.2691 3.5
-      vertex 9.75551 -22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.2815 -21.5668 3.5
-      vertex 9.48148 -21.5668 3.5
-      vertex 9.55065 -22.2691 3.5
     endloop
   endfacet
   facet normal -0.471397 -0.881921 0
@@ -6647,6 +6591,48 @@ solid OpenSCAD_Model
       vertex 15.0815 -18.5735 10
       vertex 14.4591 -18.2408 3.5
       vertex 15.0815 -18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 0
+    outer loop
+      vertex 15.0815 -18.5735 3.5
+      vertex 15.6271 -19.0212 10
+      vertex 15.0815 -18.5735 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 -0
+    outer loop
+      vertex 15.6271 -19.0212 10
+      vertex 15.0815 -18.5735 3.5
+      vertex 15.6271 -19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290284 0
+    outer loop
+      vertex 9.55065 -20.8644 10
+      vertex 9.75551 -20.1891 3.5
+      vertex 9.75551 -20.1891 10
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290284 0
+    outer loop
+      vertex 9.75551 -20.1891 3.5
+      vertex 9.55065 -20.8644 10
+      vertex 9.55065 -20.8644 3.5
+    endloop
+  endfacet
+  facet normal 0.881921 -0.471397 0
+    outer loop
+      vertex 9.75551 -20.1891 10
+      vertex 10.0882 -19.5667 3.5
+      vertex 10.0882 -19.5667 10
+    endloop
+  endfacet
+  facet normal 0.881921 -0.471397 0
+    outer loop
+      vertex 10.0882 -19.5667 3.5
+      vertex 9.75551 -20.1891 10
+      vertex 9.75551 -20.1891 3.5
     endloop
   endfacet
   facet normal 0.995185 0.0980171 0
@@ -6689,6 +6675,20 @@ solid OpenSCAD_Model
       vertex 11.7038 -18.2408 10
       vertex 11.0814 -18.5735 3.5
       vertex 11.7038 -18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex 10.5359 -19.0212 3.5
+      vertex 11.0814 -18.5735 10
+      vertex 10.5359 -19.0212 10
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex 11.0814 -18.5735 10
+      vertex 10.5359 -19.0212 3.5
+      vertex 11.0814 -18.5735 3.5
     endloop
   endfacet
   facet normal -0.0980157 -0.995185 0
@@ -7167,18 +7167,18 @@ solid OpenSCAD_Model
       vertex 19.8013 -12.7303 0
     endloop
   endfacet
-  facet normal -0.95694 -0.290285 0
+  facet normal -0.77301 -0.634394 0
     outer loop
-      vertex 25.0976 -12.3792 3.5
-      vertex 24.8927 -11.7038 10
-      vertex 24.8927 -11.7038 3.5
+      vertex 24.56 -11.0814 3.5
+      vertex 24.1123 -10.5359 10
+      vertex 24.1123 -10.5359 3.5
     endloop
   endfacet
-  facet normal -0.95694 -0.290285 0
+  facet normal -0.77301 -0.634394 0
     outer loop
-      vertex 24.8927 -11.7038 10
-      vertex 25.0976 -12.3792 3.5
-      vertex 25.0976 -12.3792 10
+      vertex 24.1123 -10.5359 10
+      vertex 24.56 -11.0814 3.5
+      vertex 24.56 -11.0814 10
     endloop
   endfacet
   facet normal 0.634395 0.773009 -0
@@ -7193,6 +7193,118 @@ solid OpenSCAD_Model
       vertex 19.0212 -15.6271 10
       vertex 19.5667 -16.0748 3.5
       vertex 19.0212 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex 24.1123 -15.6271 3.5
+      vertex 23.5668 -16.0748 10
+      vertex 24.1123 -15.6271 10
+    endloop
+  endfacet
+  facet normal -0.634394 0.77301 0
+    outer loop
+      vertex 23.5668 -16.0748 10
+      vertex 24.1123 -15.6271 3.5
+      vertex 23.5668 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex 19.0212 -10.5359 3.5
+      vertex 19.5667 -10.0882 10
+      vertex 19.0212 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0.634394 -0.77301 0
+    outer loop
+      vertex 19.5667 -10.0882 10
+      vertex 19.0212 -10.5359 3.5
+      vertex 19.5667 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980157 0
+    outer loop
+      vertex 25.0976 -13.7838 3.5
+      vertex 25.1668 -13.0815 10
+      vertex 25.1668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980157 0
+    outer loop
+      vertex 25.1668 -13.0815 10
+      vertex 25.0976 -13.7838 3.5
+      vertex 25.0976 -13.7838 10
+    endloop
+  endfacet
+  facet normal 0.0980182 0.995185 -0
+    outer loop
+      vertex 21.5668 -16.6815 3.5
+      vertex 20.8644 -16.6123 10
+      vertex 21.5668 -16.6815 10
+    endloop
+  endfacet
+  facet normal 0.0980182 0.995185 0
+    outer loop
+      vertex 20.8644 -16.6123 10
+      vertex 21.5668 -16.6815 3.5
+      vertex 20.8644 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal -0.290284 0.956941 0
+    outer loop
+      vertex 22.9444 -16.4074 3.5
+      vertex 22.2691 -16.6123 10
+      vertex 22.9444 -16.4074 10
+    endloop
+  endfacet
+  facet normal -0.290284 0.956941 0
+    outer loop
+      vertex 22.2691 -16.6123 10
+      vertex 22.9444 -16.4074 3.5
+      vertex 22.2691 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal -0.290283 -0.956941 0
+    outer loop
+      vertex 22.2691 -9.55065 3.5
+      vertex 22.9444 -9.75551 10
+      vertex 22.2691 -9.55065 10
+    endloop
+  endfacet
+  facet normal -0.290283 -0.956941 -0
+    outer loop
+      vertex 22.9444 -9.75551 10
+      vertex 22.2691 -9.55065 3.5
+      vertex 22.9444 -9.75551 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 -0.290285 0
+    outer loop
+      vertex 25.0976 -12.3792 3.5
+      vertex 24.8927 -11.7038 10
+      vertex 24.8927 -11.7038 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 -0.290285 0
+    outer loop
+      vertex 24.8927 -11.7038 10
+      vertex 25.0976 -12.3792 3.5
+      vertex 25.0976 -12.3792 10
+    endloop
+  endfacet
+  facet normal -0.881921 -0.471397 0
+    outer loop
+      vertex 24.8927 -11.7038 3.5
+      vertex 24.56 -11.0814 10
+      vertex 24.56 -11.0814 3.5
+    endloop
+  endfacet
+  facet normal -0.881921 -0.471397 0
+    outer loop
+      vertex 24.56 -11.0814 10
+      vertex 24.8927 -11.7038 3.5
+      vertex 24.8927 -11.7038 10
     endloop
   endfacet
   facet normal -0.995185 -0.0980157 0
@@ -7223,102 +7335,18 @@ solid OpenSCAD_Model
       vertex 24.56 -15.0815 10
     endloop
   endfacet
-  facet normal -0.290284 0.956941 0
-    outer loop
-      vertex 22.9444 -16.4074 3.5
-      vertex 22.2691 -16.6123 10
-      vertex 22.9444 -16.4074 10
-    endloop
-  endfacet
-  facet normal -0.290284 0.956941 0
-    outer loop
-      vertex 22.2691 -16.6123 10
-      vertex 22.9444 -16.4074 3.5
-      vertex 22.2691 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0.471395 0.881922 -0
-    outer loop
-      vertex 20.1891 -16.4074 3.5
-      vertex 19.5667 -16.0748 10
-      vertex 20.1891 -16.4074 10
-    endloop
-  endfacet
-  facet normal 0.471395 0.881922 0
-    outer loop
-      vertex 19.5667 -16.0748 10
-      vertex 20.1891 -16.4074 3.5
-      vertex 19.5667 -16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 0
-    outer loop
-      vertex 23.5668 -10.0882 3.5
-      vertex 24.1123 -10.5359 10
-      vertex 23.5668 -10.0882 10
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 -0
-    outer loop
-      vertex 24.1123 -10.5359 10
-      vertex 23.5668 -10.0882 3.5
-      vertex 24.1123 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex 19.5667 -10.0882 3.5
-      vertex 20.1891 -9.75551 10
-      vertex 19.5667 -10.0882 10
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex 20.1891 -9.75551 10
-      vertex 19.5667 -10.0882 3.5
-      vertex 20.1891 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 -0.471397 0
-    outer loop
-      vertex 24.8927 -11.7038 3.5
-      vertex 24.56 -11.0814 10
-      vertex 24.56 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 -0.471397 0
-    outer loop
-      vertex 24.56 -11.0814 10
-      vertex 24.8927 -11.7038 3.5
-      vertex 24.8927 -11.7038 10
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980157 0
-    outer loop
-      vertex 25.0976 -13.7838 3.5
-      vertex 25.1668 -13.0815 10
-      vertex 25.1668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980157 0
-    outer loop
-      vertex 25.1668 -13.0815 10
-      vertex 25.0976 -13.7838 3.5
-      vertex 25.0976 -13.7838 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
+  facet normal -0.77301 0.634394 0
     outer loop
       vertex 24.1123 -15.6271 3.5
-      vertex 23.5668 -16.0748 10
+      vertex 24.56 -15.0815 10
+      vertex 24.56 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 0.634394 0
+    outer loop
+      vertex 24.56 -15.0815 10
+      vertex 24.1123 -15.6271 3.5
       vertex 24.1123 -15.6271 10
-    endloop
-  endfacet
-  facet normal -0.634394 0.77301 0
-    outer loop
-      vertex 23.5668 -16.0748 10
-      vertex 24.1123 -15.6271 3.5
-      vertex 23.5668 -16.0748 3.5
     endloop
   endfacet
   facet normal -0.95694 0.290284 0
@@ -7349,6 +7377,20 @@ solid OpenSCAD_Model
       vertex 20.1891 -16.4074 3.5
     endloop
   endfacet
+  facet normal 0.471395 0.881922 -0
+    outer loop
+      vertex 20.1891 -16.4074 3.5
+      vertex 19.5667 -16.0748 10
+      vertex 20.1891 -16.4074 10
+    endloop
+  endfacet
+  facet normal 0.471395 0.881922 0
+    outer loop
+      vertex 19.5667 -16.0748 10
+      vertex 20.1891 -16.4074 3.5
+      vertex 19.5667 -16.0748 3.5
+    endloop
+  endfacet
   facet normal -0.0980185 0.995185 0
     outer loop
       vertex 22.2691 -16.6123 3.5
@@ -7377,32 +7419,452 @@ solid OpenSCAD_Model
       vertex 22.9444 -16.4074 3.5
     endloop
   endfacet
-  facet normal 0.0980182 0.995185 -0
+  facet normal 0 0 1
     outer loop
-      vertex 21.5668 -16.6815 3.5
-      vertex 20.8644 -16.6123 10
-      vertex 21.5668 -16.6815 10
+      vertex 23.3668 -13.0815 3.5
+      vertex 25.1668 -13.0815 3.5
+      vertex 25.0976 -12.3792 3.5
     endloop
   endfacet
-  facet normal 0.0980182 0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex 20.8644 -16.6123 10
-      vertex 21.5668 -16.6815 3.5
-      vertex 20.8644 -16.6123 3.5
+      vertex 23.3322 -12.7303 3.5
+      vertex 25.0976 -12.3792 3.5
+      vertex 24.8927 -11.7038 3.5
     endloop
   endfacet
-  facet normal -0.77301 -0.634394 0
+  facet normal 0 0 1
     outer loop
+      vertex 25.1668 -13.0815 3.5
+      vertex 23.3668 -13.0815 3.5
+      vertex 25.0976 -13.7838 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.2297 -12.3926 3.5
+      vertex 24.8927 -11.7038 3.5
       vertex 24.56 -11.0814 3.5
-      vertex 24.1123 -10.5359 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.3322 -13.4326 3.5
+      vertex 25.0976 -13.7838 3.5
+      vertex 23.3668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0634 -12.0814 3.5
+      vertex 24.56 -11.0814 3.5
       vertex 24.1123 -10.5359 3.5
     endloop
   endfacet
-  facet normal -0.77301 -0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex 24.1123 -10.5359 10
+      vertex 25.0976 -13.7838 3.5
+      vertex 23.3322 -13.4326 3.5
+      vertex 24.8927 -14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.8395 -11.8087 3.5
+      vertex 24.1123 -10.5359 3.5
+      vertex 23.5668 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.2297 -13.7703 3.5
+      vertex 24.8927 -14.4591 3.5
+      vertex 23.3322 -13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8927 -14.4591 3.5
+      vertex 23.2297 -13.7703 3.5
+      vertex 24.56 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.0976 -12.3792 3.5
+      vertex 23.3322 -12.7303 3.5
+      vertex 23.3668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8927 -11.7038 3.5
+      vertex 23.2297 -12.3926 3.5
+      vertex 23.3322 -12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex 24.56 -11.0814 3.5
-      vertex 24.56 -11.0814 10
+      vertex 23.0634 -12.0814 3.5
+      vertex 23.2297 -12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5668 -11.5848 3.5
+      vertex 23.5668 -10.0882 3.5
+      vertex 22.9444 -9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 -10.5359 3.5
+      vertex 22.8395 -11.8087 3.5
+      vertex 23.0634 -12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 -10.0882 3.5
+      vertex 22.5668 -11.5848 3.5
+      vertex 22.8395 -11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2556 -11.4185 3.5
+      vertex 22.9444 -9.75551 3.5
+      vertex 22.2691 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 -9.75551 3.5
+      vertex 22.2556 -11.4185 3.5
+      vertex 22.5668 -11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2691 -9.55065 3.5
+      vertex 21.9179 -11.3161 3.5
+      vertex 22.2556 -11.4185 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 -9.48148 3.5
+      vertex 21.9179 -11.3161 3.5
+      vertex 22.2691 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 -9.48148 3.5
+      vertex 21.5668 -11.2815 3.5
+      vertex 21.9179 -11.3161 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 -9.48148 3.5
+      vertex 21.2156 -11.3161 3.5
+      vertex 21.5668 -11.2815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.8644 -9.55065 3.5
+      vertex 21.2156 -11.3161 3.5
+      vertex 21.5668 -9.48148 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 -11.3161 3.5
+      vertex 20.8644 -9.55065 3.5
+      vertex 20.8779 -11.4185 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1891 -9.75551 3.5
+      vertex 20.8779 -11.4185 3.5
+      vertex 20.8644 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8779 -11.4185 3.5
+      vertex 20.1891 -9.75551 3.5
+      vertex 20.5667 -11.5848 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.5667 -10.0882 3.5
+      vertex 20.5667 -11.5848 3.5
+      vertex 20.1891 -9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5667 -11.5848 3.5
+      vertex 19.5667 -10.0882 3.5
+      vertex 20.294 -11.8087 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.0212 -10.5359 3.5
+      vertex 20.294 -11.8087 3.5
+      vertex 19.5667 -10.0882 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.294 -11.8087 3.5
+      vertex 19.0212 -10.5359 3.5
+      vertex 20.0701 -12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.0701 -12.0814 3.5
+      vertex 18.5735 -11.0814 3.5
+      vertex 19.9038 -12.3926 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5735 -11.0814 3.5
+      vertex 20.0701 -12.0814 3.5
+      vertex 19.0212 -10.5359 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0634 -14.0815 3.5
+      vertex 24.56 -15.0815 3.5
+      vertex 23.2297 -13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.56 -15.0815 3.5
+      vertex 23.0634 -14.0815 3.5
+      vertex 24.1123 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.8395 -14.3543 3.5
+      vertex 24.1123 -15.6271 3.5
+      vertex 23.0634 -14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 -15.6271 3.5
+      vertex 22.8395 -14.3543 3.5
+      vertex 23.5668 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5668 -14.5781 3.5
+      vertex 23.5668 -16.0748 3.5
+      vertex 22.8395 -14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 -16.0748 3.5
+      vertex 22.5668 -14.5781 3.5
+      vertex 22.9444 -16.4074 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.2556 -14.7445 3.5
+      vertex 22.9444 -16.4074 3.5
+      vertex 22.5668 -14.5781 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 -16.4074 3.5
+      vertex 22.2556 -14.7445 3.5
+      vertex 22.2691 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.9179 -14.8469 3.5
+      vertex 22.2691 -16.6123 3.5
+      vertex 22.2556 -14.7445 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5668 -14.8815 3.5
+      vertex 22.2691 -16.6123 3.5
+      vertex 21.9179 -14.8469 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 -14.8815 3.5
+      vertex 21.5668 -16.6815 3.5
+      vertex 22.2691 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 -14.8469 3.5
+      vertex 21.5668 -16.6815 3.5
+      vertex 21.5668 -14.8815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 -16.6123 3.5
+      vertex 21.2156 -14.8469 3.5
+      vertex 20.8779 -14.7445 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 -14.8469 3.5
+      vertex 20.8644 -16.6123 3.5
+      vertex 21.5668 -16.6815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1891 -16.4074 3.5
+      vertex 20.8779 -14.7445 3.5
+      vertex 20.5667 -14.5781 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 -16.0748 3.5
+      vertex 20.5667 -14.5781 3.5
+      vertex 20.294 -14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8779 -14.7445 3.5
+      vertex 20.1891 -16.4074 3.5
+      vertex 20.8644 -16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 -15.6271 3.5
+      vertex 20.294 -14.3543 3.5
+      vertex 20.0701 -14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 -15.0815 3.5
+      vertex 20.0701 -14.0815 3.5
+      vertex 19.9038 -13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 -14.4591 3.5
+      vertex 19.9038 -13.7703 3.5
+      vertex 19.8013 -13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5667 -14.5781 3.5
+      vertex 19.5667 -16.0748 3.5
+      vertex 20.1891 -16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 -13.7838 3.5
+      vertex 19.8013 -13.4326 3.5
+      vertex 19.7668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2408 -11.7038 3.5
+      vertex 19.9038 -12.3926 3.5
+      vertex 18.5735 -11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.9038 -12.3926 3.5
+      vertex 18.2408 -11.7038 3.5
+      vertex 19.8013 -12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.294 -14.3543 3.5
+      vertex 19.0212 -15.6271 3.5
+      vertex 19.5667 -16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0359 -12.3792 3.5
+      vertex 19.8013 -12.7303 3.5
+      vertex 18.2408 -11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.0701 -14.0815 3.5
+      vertex 18.5735 -15.0815 3.5
+      vertex 19.0212 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8013 -12.7303 3.5
+      vertex 18.0359 -12.3792 3.5
+      vertex 19.7668 -13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.9038 -13.7703 3.5
+      vertex 18.2408 -14.4591 3.5
+      vertex 18.5735 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9668 -13.0815 3.5
+      vertex 19.7668 -13.0815 3.5
+      vertex 18.0359 -12.3792 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8013 -13.4326 3.5
+      vertex 18.0359 -13.7838 3.5
+      vertex 18.2408 -14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7668 -13.0815 3.5
+      vertex 17.9668 -13.0815 3.5
+      vertex 18.0359 -13.7838 3.5
     endloop
   endfacet
   facet normal -0.471398 -0.881921 0
@@ -7419,60 +7881,18 @@ solid OpenSCAD_Model
       vertex 23.5668 -10.0882 3.5
     endloop
   endfacet
-  facet normal 0.0980169 -0.995185 0
+  facet normal -0.634393 -0.773011 0
     outer loop
-      vertex 20.8644 -9.55065 3.5
-      vertex 21.5668 -9.48148 10
-      vertex 20.8644 -9.55065 10
+      vertex 23.5668 -10.0882 3.5
+      vertex 24.1123 -10.5359 10
+      vertex 23.5668 -10.0882 10
     endloop
   endfacet
-  facet normal 0.0980169 -0.995185 0
+  facet normal -0.634393 -0.773011 -0
     outer loop
-      vertex 21.5668 -9.48148 10
-      vertex 20.8644 -9.55065 3.5
-      vertex 21.5668 -9.48148 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex 24.1123 -15.6271 3.5
-      vertex 24.56 -15.0815 10
-      vertex 24.56 -15.0815 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 0.634394 0
-    outer loop
-      vertex 24.56 -15.0815 10
-      vertex 24.1123 -15.6271 3.5
-      vertex 24.1123 -15.6271 10
-    endloop
-  endfacet
-  facet normal -0.290283 -0.956941 0
-    outer loop
-      vertex 22.2691 -9.55065 3.5
-      vertex 22.9444 -9.75551 10
-      vertex 22.2691 -9.55065 10
-    endloop
-  endfacet
-  facet normal -0.290283 -0.956941 -0
-    outer loop
-      vertex 22.9444 -9.75551 10
-      vertex 22.2691 -9.55065 3.5
-      vertex 22.9444 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex 19.0212 -15.6271 10
-      vertex 18.5735 -15.0815 3.5
-      vertex 18.5735 -15.0815 10
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex 18.5735 -15.0815 3.5
-      vertex 19.0212 -15.6271 10
-      vertex 19.0212 -15.6271 3.5
+      vertex 24.1123 -10.5359 10
+      vertex 23.5668 -10.0882 3.5
+      vertex 24.1123 -10.5359 3.5
     endloop
   endfacet
   facet normal 0.95694 0.290284 0
@@ -7489,494 +7909,18 @@ solid OpenSCAD_Model
       vertex 18.2408 -14.4591 3.5
     endloop
   endfacet
-  facet normal 0.290284 -0.956941 0
+  facet normal 0.0980169 -0.995185 0
     outer loop
-      vertex 20.1891 -9.75551 3.5
+      vertex 20.8644 -9.55065 3.5
+      vertex 21.5668 -9.48148 10
       vertex 20.8644 -9.55065 10
-      vertex 20.1891 -9.75551 10
     endloop
   endfacet
-  facet normal 0.290284 -0.956941 0
+  facet normal 0.0980169 -0.995185 0
     outer loop
-      vertex 20.8644 -9.55065 10
-      vertex 20.1891 -9.75551 3.5
+      vertex 21.5668 -9.48148 10
       vertex 20.8644 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex 18.5735 -11.0814 10
-      vertex 19.0212 -10.5359 3.5
-      vertex 19.0212 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0.77301 -0.634394 0
-    outer loop
-      vertex 19.0212 -10.5359 3.5
-      vertex 18.5735 -11.0814 10
-      vertex 18.5735 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex 19.0212 -10.5359 3.5
-      vertex 19.5667 -10.0882 10
-      vertex 19.0212 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0.634394 -0.77301 0
-    outer loop
-      vertex 19.5667 -10.0882 10
-      vertex 19.0212 -10.5359 3.5
-      vertex 19.5667 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.3668 -13.0815 3.5
-      vertex 25.1668 -13.0815 3.5
-      vertex 25.0976 -12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.3322 -12.7303 3.5
-      vertex 25.0976 -12.3792 3.5
-      vertex 24.8927 -11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.1668 -13.0815 3.5
-      vertex 23.3668 -13.0815 3.5
-      vertex 25.0976 -13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2297 -12.3926 3.5
-      vertex 24.8927 -11.7038 3.5
-      vertex 24.56 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.3322 -13.4326 3.5
-      vertex 25.0976 -13.7838 3.5
-      vertex 23.3668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.0634 -12.0814 3.5
-      vertex 24.56 -11.0814 3.5
-      vertex 24.1123 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.0976 -13.7838 3.5
-      vertex 23.3322 -13.4326 3.5
-      vertex 24.8927 -14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.8395 -11.8087 3.5
-      vertex 24.1123 -10.5359 3.5
-      vertex 23.5668 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.2297 -13.7703 3.5
-      vertex 24.8927 -14.4591 3.5
-      vertex 23.3322 -13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8927 -14.4591 3.5
-      vertex 23.2297 -13.7703 3.5
-      vertex 24.56 -15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.0976 -12.3792 3.5
-      vertex 23.3322 -12.7303 3.5
-      vertex 23.3668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8927 -11.7038 3.5
-      vertex 23.2297 -12.3926 3.5
-      vertex 23.3322 -12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 -11.0814 3.5
-      vertex 23.0634 -12.0814 3.5
-      vertex 23.2297 -12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.5668 -11.5848 3.5
-      vertex 23.5668 -10.0882 3.5
-      vertex 22.9444 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 -10.5359 3.5
-      vertex 22.8395 -11.8087 3.5
-      vertex 23.0634 -12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 -10.0882 3.5
-      vertex 22.5668 -11.5848 3.5
-      vertex 22.8395 -11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2556 -11.4185 3.5
-      vertex 22.9444 -9.75551 3.5
-      vertex 22.2691 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 -9.75551 3.5
-      vertex 22.2556 -11.4185 3.5
-      vertex 22.5668 -11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2691 -9.55065 3.5
-      vertex 21.9179 -11.3161 3.5
-      vertex 22.2556 -11.4185 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
       vertex 21.5668 -9.48148 3.5
-      vertex 21.9179 -11.3161 3.5
-      vertex 22.2691 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 -9.48148 3.5
-      vertex 21.5668 -11.2815 3.5
-      vertex 21.9179 -11.3161 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 -9.48148 3.5
-      vertex 21.2156 -11.3161 3.5
-      vertex 21.5668 -11.2815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.8644 -9.55065 3.5
-      vertex 21.2156 -11.3161 3.5
-      vertex 21.5668 -9.48148 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 -11.3161 3.5
-      vertex 20.8644 -9.55065 3.5
-      vertex 20.8779 -11.4185 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.1891 -9.75551 3.5
-      vertex 20.8779 -11.4185 3.5
-      vertex 20.8644 -9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8779 -11.4185 3.5
-      vertex 20.1891 -9.75551 3.5
-      vertex 20.5667 -11.5848 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.5667 -10.0882 3.5
-      vertex 20.5667 -11.5848 3.5
-      vertex 20.1891 -9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.5667 -11.5848 3.5
-      vertex 19.5667 -10.0882 3.5
-      vertex 20.294 -11.8087 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.0212 -10.5359 3.5
-      vertex 20.294 -11.8087 3.5
-      vertex 19.5667 -10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.294 -11.8087 3.5
-      vertex 19.0212 -10.5359 3.5
-      vertex 20.0701 -12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.0701 -12.0814 3.5
-      vertex 18.5735 -11.0814 3.5
-      vertex 19.9038 -12.3926 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.5735 -11.0814 3.5
-      vertex 20.0701 -12.0814 3.5
-      vertex 19.0212 -10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.0634 -14.0815 3.5
-      vertex 24.56 -15.0815 3.5
-      vertex 23.2297 -13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 -15.0815 3.5
-      vertex 23.0634 -14.0815 3.5
-      vertex 24.1123 -15.6271 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.8395 -14.3543 3.5
-      vertex 24.1123 -15.6271 3.5
-      vertex 23.0634 -14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 -15.6271 3.5
-      vertex 22.8395 -14.3543 3.5
-      vertex 23.5668 -16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.5668 -14.5781 3.5
-      vertex 23.5668 -16.0748 3.5
-      vertex 22.8395 -14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 -16.0748 3.5
-      vertex 22.5668 -14.5781 3.5
-      vertex 22.9444 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.2556 -14.7445 3.5
-      vertex 22.9444 -16.4074 3.5
-      vertex 22.5668 -14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 -16.4074 3.5
-      vertex 22.2556 -14.7445 3.5
-      vertex 22.2691 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.9179 -14.8469 3.5
-      vertex 22.2691 -16.6123 3.5
-      vertex 22.2556 -14.7445 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.5668 -14.8815 3.5
-      vertex 22.2691 -16.6123 3.5
-      vertex 21.9179 -14.8469 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 -14.8815 3.5
-      vertex 21.5668 -16.6815 3.5
-      vertex 22.2691 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 -14.8469 3.5
-      vertex 21.5668 -16.6815 3.5
-      vertex 21.5668 -14.8815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 -16.6123 3.5
-      vertex 21.2156 -14.8469 3.5
-      vertex 20.8779 -14.7445 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 -14.8469 3.5
-      vertex 20.8644 -16.6123 3.5
-      vertex 21.5668 -16.6815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 -16.4074 3.5
-      vertex 20.8779 -14.7445 3.5
-      vertex 20.5667 -14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 -16.0748 3.5
-      vertex 20.5667 -14.5781 3.5
-      vertex 20.294 -14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8779 -14.7445 3.5
-      vertex 20.1891 -16.4074 3.5
-      vertex 20.8644 -16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 -15.6271 3.5
-      vertex 20.294 -14.3543 3.5
-      vertex 20.0701 -14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 -15.0815 3.5
-      vertex 20.0701 -14.0815 3.5
-      vertex 19.9038 -13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 -14.4591 3.5
-      vertex 19.9038 -13.7703 3.5
-      vertex 19.8013 -13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.5667 -14.5781 3.5
-      vertex 19.5667 -16.0748 3.5
-      vertex 20.1891 -16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 -13.7838 3.5
-      vertex 19.8013 -13.4326 3.5
-      vertex 19.7668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.2408 -11.7038 3.5
-      vertex 19.9038 -12.3926 3.5
-      vertex 18.5735 -11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.9038 -12.3926 3.5
-      vertex 18.2408 -11.7038 3.5
-      vertex 19.8013 -12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.294 -14.3543 3.5
-      vertex 19.0212 -15.6271 3.5
-      vertex 19.5667 -16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.0359 -12.3792 3.5
-      vertex 19.8013 -12.7303 3.5
-      vertex 18.2408 -11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.0701 -14.0815 3.5
-      vertex 18.5735 -15.0815 3.5
-      vertex 19.0212 -15.6271 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8013 -12.7303 3.5
-      vertex 18.0359 -12.3792 3.5
-      vertex 19.7668 -13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.9038 -13.7703 3.5
-      vertex 18.2408 -14.4591 3.5
-      vertex 18.5735 -15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9668 -13.0815 3.5
-      vertex 19.7668 -13.0815 3.5
-      vertex 18.0359 -12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8013 -13.4326 3.5
-      vertex 18.0359 -13.7838 3.5
-      vertex 18.2408 -14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.7668 -13.0815 3.5
-      vertex 17.9668 -13.0815 3.5
-      vertex 18.0359 -13.7838 3.5
     endloop
   endfacet
   facet normal 0.881921 0.471397 0
@@ -7991,6 +7935,48 @@ solid OpenSCAD_Model
       vertex 18.2408 -14.4591 3.5
       vertex 18.5735 -15.0815 10
       vertex 18.5735 -15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 19.0212 -15.6271 10
+      vertex 18.5735 -15.0815 3.5
+      vertex 18.5735 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 18.5735 -15.0815 3.5
+      vertex 19.0212 -15.6271 10
+      vertex 19.0212 -15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0.290284 -0.956941 0
+    outer loop
+      vertex 20.1891 -9.75551 3.5
+      vertex 20.8644 -9.55065 10
+      vertex 20.1891 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0.290284 -0.956941 0
+    outer loop
+      vertex 20.8644 -9.55065 10
+      vertex 20.1891 -9.75551 3.5
+      vertex 20.8644 -9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0.471397 -0.881921 0
+    outer loop
+      vertex 19.5667 -10.0882 3.5
+      vertex 20.1891 -9.75551 10
+      vertex 19.5667 -10.0882 10
+    endloop
+  endfacet
+  facet normal 0.471397 -0.881921 0
+    outer loop
+      vertex 20.1891 -9.75551 10
+      vertex 19.5667 -10.0882 3.5
+      vertex 20.1891 -9.75551 3.5
     endloop
   endfacet
   facet normal -0.0980171 -0.995185 0
@@ -8033,6 +8019,20 @@ solid OpenSCAD_Model
       vertex 18.5735 -11.0814 3.5
       vertex 18.2408 -11.7038 10
       vertex 18.2408 -11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex 18.5735 -11.0814 10
+      vertex 19.0212 -10.5359 3.5
+      vertex 19.0212 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0.77301 -0.634394 0
+    outer loop
+      vertex 19.0212 -10.5359 3.5
+      vertex 18.5735 -11.0814 10
+      vertex 18.5735 -11.0814 3.5
     endloop
   endfacet
   facet normal 0.995185 0.0980157 0
@@ -8511,18 +8511,18 @@ solid OpenSCAD_Model
       vertex 19.9038 12.3926 0
     endloop
   endfacet
-  facet normal -0.95694 0.290285 0
+  facet normal -0.77301 0.634394 0
     outer loop
-      vertex 24.8927 11.7038 3.5
-      vertex 25.0976 12.3792 10
-      vertex 25.0976 12.3792 3.5
+      vertex 24.1123 10.5359 3.5
+      vertex 24.56 11.0814 10
+      vertex 24.56 11.0814 3.5
     endloop
   endfacet
-  facet normal -0.95694 0.290285 0
+  facet normal -0.77301 0.634394 0
     outer loop
-      vertex 25.0976 12.3792 10
-      vertex 24.8927 11.7038 3.5
-      vertex 24.8927 11.7038 10
+      vertex 24.56 11.0814 10
+      vertex 24.1123 10.5359 3.5
+      vertex 24.1123 10.5359 10
     endloop
   endfacet
   facet normal 0.634395 -0.773009 0
@@ -8537,6 +8537,118 @@ solid OpenSCAD_Model
       vertex 19.5667 16.0748 10
       vertex 19.0212 15.6271 3.5
       vertex 19.5667 16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 0
+    outer loop
+      vertex 23.5668 16.0748 3.5
+      vertex 24.1123 15.6271 10
+      vertex 23.5668 16.0748 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 -0
+    outer loop
+      vertex 24.1123 15.6271 10
+      vertex 23.5668 16.0748 3.5
+      vertex 24.1123 15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 -0
+    outer loop
+      vertex 19.5667 10.0882 3.5
+      vertex 19.0212 10.5359 10
+      vertex 19.5667 10.0882 10
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 0
+    outer loop
+      vertex 19.0212 10.5359 10
+      vertex 19.5667 10.0882 3.5
+      vertex 19.0212 10.5359 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980157 0
+    outer loop
+      vertex 25.1668 13.0815 3.5
+      vertex 25.0976 13.7838 10
+      vertex 25.0976 13.7838 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980157 0
+    outer loop
+      vertex 25.0976 13.7838 10
+      vertex 25.1668 13.0815 3.5
+      vertex 25.1668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0.0980182 -0.995185 0
+    outer loop
+      vertex 20.8644 16.6123 3.5
+      vertex 21.5668 16.6815 10
+      vertex 20.8644 16.6123 10
+    endloop
+  endfacet
+  facet normal 0.0980182 -0.995185 0
+    outer loop
+      vertex 21.5668 16.6815 10
+      vertex 20.8644 16.6123 3.5
+      vertex 21.5668 16.6815 3.5
+    endloop
+  endfacet
+  facet normal -0.290284 -0.956941 0
+    outer loop
+      vertex 22.2691 16.6123 3.5
+      vertex 22.9444 16.4074 10
+      vertex 22.2691 16.6123 10
+    endloop
+  endfacet
+  facet normal -0.290284 -0.956941 -0
+    outer loop
+      vertex 22.9444 16.4074 10
+      vertex 22.2691 16.6123 3.5
+      vertex 22.9444 16.4074 3.5
+    endloop
+  endfacet
+  facet normal -0.290283 0.956941 0
+    outer loop
+      vertex 22.9444 9.75551 3.5
+      vertex 22.2691 9.55065 10
+      vertex 22.9444 9.75551 10
+    endloop
+  endfacet
+  facet normal -0.290283 0.956941 0
+    outer loop
+      vertex 22.2691 9.55065 10
+      vertex 22.9444 9.75551 3.5
+      vertex 22.2691 9.55065 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 0.290285 0
+    outer loop
+      vertex 24.8927 11.7038 3.5
+      vertex 25.0976 12.3792 10
+      vertex 25.0976 12.3792 3.5
+    endloop
+  endfacet
+  facet normal -0.95694 0.290285 0
+    outer loop
+      vertex 25.0976 12.3792 10
+      vertex 24.8927 11.7038 3.5
+      vertex 24.8927 11.7038 10
+    endloop
+  endfacet
+  facet normal -0.881921 0.471397 0
+    outer loop
+      vertex 24.56 11.0814 3.5
+      vertex 24.8927 11.7038 10
+      vertex 24.8927 11.7038 3.5
+    endloop
+  endfacet
+  facet normal -0.881921 0.471397 0
+    outer loop
+      vertex 24.8927 11.7038 10
+      vertex 24.56 11.0814 3.5
+      vertex 24.56 11.0814 10
     endloop
   endfacet
   facet normal -0.995185 0.0980157 0
@@ -8567,102 +8679,18 @@ solid OpenSCAD_Model
       vertex 24.8927 14.4591 10
     endloop
   endfacet
-  facet normal -0.290284 -0.956941 0
+  facet normal -0.77301 -0.634394 0
     outer loop
-      vertex 22.2691 16.6123 3.5
-      vertex 22.9444 16.4074 10
-      vertex 22.2691 16.6123 10
-    endloop
-  endfacet
-  facet normal -0.290284 -0.956941 -0
-    outer loop
-      vertex 22.9444 16.4074 10
-      vertex 22.2691 16.6123 3.5
-      vertex 22.9444 16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0.471395 -0.881922 0
-    outer loop
-      vertex 19.5667 16.0748 3.5
-      vertex 20.1891 16.4074 10
-      vertex 19.5667 16.0748 10
-    endloop
-  endfacet
-  facet normal 0.471395 -0.881922 0
-    outer loop
-      vertex 20.1891 16.4074 10
-      vertex 19.5667 16.0748 3.5
-      vertex 20.1891 16.4074 3.5
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 24.1123 10.5359 3.5
-      vertex 23.5668 10.0882 10
-      vertex 24.1123 10.5359 10
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 23.5668 10.0882 10
-      vertex 24.1123 10.5359 3.5
-      vertex 23.5668 10.0882 3.5
-    endloop
-  endfacet
-  facet normal 0.471397 0.881921 -0
-    outer loop
-      vertex 20.1891 9.75551 3.5
-      vertex 19.5667 10.0882 10
-      vertex 20.1891 9.75551 10
-    endloop
-  endfacet
-  facet normal 0.471397 0.881921 0
-    outer loop
-      vertex 19.5667 10.0882 10
-      vertex 20.1891 9.75551 3.5
-      vertex 19.5667 10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex 24.56 11.0814 3.5
-      vertex 24.8927 11.7038 10
-      vertex 24.8927 11.7038 3.5
-    endloop
-  endfacet
-  facet normal -0.881921 0.471397 0
-    outer loop
-      vertex 24.8927 11.7038 10
-      vertex 24.56 11.0814 3.5
-      vertex 24.56 11.0814 10
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980157 0
-    outer loop
-      vertex 25.1668 13.0815 3.5
-      vertex 25.0976 13.7838 10
-      vertex 25.0976 13.7838 3.5
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980157 0
-    outer loop
-      vertex 25.0976 13.7838 10
-      vertex 25.1668 13.0815 3.5
-      vertex 25.1668 13.0815 10
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 0
-    outer loop
-      vertex 23.5668 16.0748 3.5
+      vertex 24.56 15.0815 3.5
       vertex 24.1123 15.6271 10
-      vertex 23.5668 16.0748 10
-    endloop
-  endfacet
-  facet normal -0.634394 -0.77301 -0
-    outer loop
-      vertex 24.1123 15.6271 10
-      vertex 23.5668 16.0748 3.5
       vertex 24.1123 15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex 24.1123 15.6271 10
+      vertex 24.56 15.0815 3.5
+      vertex 24.56 15.0815 10
     endloop
   endfacet
   facet normal -0.95694 -0.290284 0
@@ -8691,6 +8719,20 @@ solid OpenSCAD_Model
       vertex 20.8644 16.6123 10
       vertex 20.1891 16.4074 3.5
       vertex 20.8644 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0.471395 -0.881922 0
+    outer loop
+      vertex 19.5667 16.0748 3.5
+      vertex 20.1891 16.4074 10
+      vertex 19.5667 16.0748 10
+    endloop
+  endfacet
+  facet normal 0.471395 -0.881922 0
+    outer loop
+      vertex 20.1891 16.4074 10
+      vertex 19.5667 16.0748 3.5
+      vertex 20.1891 16.4074 3.5
     endloop
   endfacet
   facet normal -0.0980185 -0.995185 0
@@ -8721,32 +8763,452 @@ solid OpenSCAD_Model
       vertex 23.5668 16.0748 3.5
     endloop
   endfacet
-  facet normal 0.0980182 -0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex 20.8644 16.6123 3.5
-      vertex 21.5668 16.6815 10
-      vertex 20.8644 16.6123 10
+      vertex 23.3668 13.0815 3.5
+      vertex 25.1668 13.0815 3.5
+      vertex 25.0976 13.7838 3.5
     endloop
   endfacet
-  facet normal 0.0980182 -0.995185 0
+  facet normal 0 0 1
     outer loop
-      vertex 21.5668 16.6815 10
-      vertex 20.8644 16.6123 3.5
-      vertex 21.5668 16.6815 3.5
+      vertex 23.3322 13.4326 3.5
+      vertex 25.0976 13.7838 3.5
+      vertex 24.8927 14.4591 3.5
     endloop
   endfacet
-  facet normal -0.77301 0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex 24.1123 10.5359 3.5
-      vertex 24.56 11.0814 10
+      vertex 25.1668 13.0815 3.5
+      vertex 23.3668 13.0815 3.5
+      vertex 25.0976 12.3792 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.2297 13.7703 3.5
+      vertex 24.8927 14.4591 3.5
+      vertex 24.56 15.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.3322 12.7303 3.5
+      vertex 25.0976 12.3792 3.5
+      vertex 23.3668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0634 14.0815 3.5
+      vertex 24.56 15.0815 3.5
+      vertex 24.1123 15.6271 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.0976 12.3792 3.5
+      vertex 23.3322 12.7303 3.5
+      vertex 24.8927 11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.8395 14.3543 3.5
+      vertex 24.1123 15.6271 3.5
+      vertex 23.5668 16.0748 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.2297 12.3926 3.5
+      vertex 24.8927 11.7038 3.5
+      vertex 23.3322 12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8927 11.7038 3.5
+      vertex 23.2297 12.3926 3.5
       vertex 24.56 11.0814 3.5
     endloop
   endfacet
-  facet normal -0.77301 0.634394 0
+  facet normal 0 0 1
     outer loop
-      vertex 24.56 11.0814 10
+      vertex 25.0976 13.7838 3.5
+      vertex 23.3322 13.4326 3.5
+      vertex 23.3668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8927 14.4591 3.5
+      vertex 23.2297 13.7703 3.5
+      vertex 23.3322 13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.56 15.0815 3.5
+      vertex 23.0634 14.0815 3.5
+      vertex 23.2297 13.7703 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5668 14.5781 3.5
+      vertex 23.5668 16.0748 3.5
+      vertex 22.9444 16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 15.6271 3.5
+      vertex 22.8395 14.3543 3.5
+      vertex 23.0634 14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 16.0748 3.5
+      vertex 22.5668 14.5781 3.5
+      vertex 22.8395 14.3543 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2556 14.7445 3.5
+      vertex 22.9444 16.4074 3.5
+      vertex 22.2691 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 16.4074 3.5
+      vertex 22.2556 14.7445 3.5
+      vertex 22.5668 14.5781 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2691 16.6123 3.5
+      vertex 21.9179 14.8469 3.5
+      vertex 22.2556 14.7445 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 16.6815 3.5
+      vertex 21.9179 14.8469 3.5
+      vertex 22.2691 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 16.6815 3.5
+      vertex 21.5668 14.8815 3.5
+      vertex 21.9179 14.8469 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 16.6815 3.5
+      vertex 21.2156 14.8469 3.5
+      vertex 21.5668 14.8815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.8644 16.6123 3.5
+      vertex 21.2156 14.8469 3.5
+      vertex 21.5668 16.6815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 14.8469 3.5
+      vertex 20.8644 16.6123 3.5
+      vertex 20.8779 14.7445 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1891 16.4074 3.5
+      vertex 20.8779 14.7445 3.5
+      vertex 20.8644 16.6123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8779 14.7445 3.5
+      vertex 20.1891 16.4074 3.5
+      vertex 20.5667 14.5781 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.5667 16.0748 3.5
+      vertex 20.5667 14.5781 3.5
+      vertex 20.1891 16.4074 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5667 14.5781 3.5
+      vertex 19.5667 16.0748 3.5
+      vertex 20.294 14.3543 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.0212 15.6271 3.5
+      vertex 20.294 14.3543 3.5
+      vertex 19.5667 16.0748 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.294 14.3543 3.5
+      vertex 19.0212 15.6271 3.5
+      vertex 20.0701 14.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.0701 14.0815 3.5
+      vertex 18.5735 15.0815 3.5
+      vertex 19.9038 13.7703 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5735 15.0815 3.5
+      vertex 20.0701 14.0815 3.5
+      vertex 19.0212 15.6271 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0634 12.0814 3.5
+      vertex 24.56 11.0814 3.5
+      vertex 23.2297 12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.56 11.0814 3.5
+      vertex 23.0634 12.0814 3.5
       vertex 24.1123 10.5359 3.5
-      vertex 24.1123 10.5359 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.8395 11.8087 3.5
+      vertex 24.1123 10.5359 3.5
+      vertex 23.0634 12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 10.5359 3.5
+      vertex 22.8395 11.8087 3.5
+      vertex 23.5668 10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5668 11.5848 3.5
+      vertex 23.5668 10.0882 3.5
+      vertex 22.8395 11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 10.0882 3.5
+      vertex 22.5668 11.5848 3.5
+      vertex 22.9444 9.75551 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.2556 11.4185 3.5
+      vertex 22.9444 9.75551 3.5
+      vertex 22.5668 11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 9.75551 3.5
+      vertex 22.2556 11.4185 3.5
+      vertex 22.2691 9.55065 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.9179 11.3161 3.5
+      vertex 22.2691 9.55065 3.5
+      vertex 22.2556 11.4185 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5668 11.2815 3.5
+      vertex 22.2691 9.55065 3.5
+      vertex 21.9179 11.3161 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 11.2815 3.5
+      vertex 21.5668 9.48148 3.5
+      vertex 22.2691 9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 11.3161 3.5
+      vertex 21.5668 9.48148 3.5
+      vertex 21.5668 11.2815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 9.55065 3.5
+      vertex 21.2156 11.3161 3.5
+      vertex 20.8779 11.4185 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.2156 11.3161 3.5
+      vertex 20.8644 9.55065 3.5
+      vertex 21.5668 9.48148 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1891 9.75551 3.5
+      vertex 20.8779 11.4185 3.5
+      vertex 20.5667 11.5848 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 10.0882 3.5
+      vertex 20.5667 11.5848 3.5
+      vertex 20.294 11.8087 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8779 11.4185 3.5
+      vertex 20.1891 9.75551 3.5
+      vertex 20.8644 9.55065 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 10.5359 3.5
+      vertex 20.294 11.8087 3.5
+      vertex 20.0701 12.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 11.0814 3.5
+      vertex 20.0701 12.0814 3.5
+      vertex 19.9038 12.3926 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 11.7038 3.5
+      vertex 19.9038 12.3926 3.5
+      vertex 19.8013 12.7303 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5667 11.5848 3.5
+      vertex 19.5667 10.0882 3.5
+      vertex 20.1891 9.75551 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 12.3792 3.5
+      vertex 19.8013 12.7303 3.5
+      vertex 19.7668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2408 14.4591 3.5
+      vertex 19.9038 13.7703 3.5
+      vertex 18.5735 15.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.9038 13.7703 3.5
+      vertex 18.2408 14.4591 3.5
+      vertex 19.8013 13.4326 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.294 11.8087 3.5
+      vertex 19.0212 10.5359 3.5
+      vertex 19.5667 10.0882 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0359 13.7838 3.5
+      vertex 19.8013 13.4326 3.5
+      vertex 18.2408 14.4591 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.0701 12.0814 3.5
+      vertex 18.5735 11.0814 3.5
+      vertex 19.0212 10.5359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8013 13.4326 3.5
+      vertex 18.0359 13.7838 3.5
+      vertex 19.7668 13.0815 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.9038 12.3926 3.5
+      vertex 18.2408 11.7038 3.5
+      vertex 18.5735 11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9668 13.0815 3.5
+      vertex 19.7668 13.0815 3.5
+      vertex 18.0359 13.7838 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8013 12.7303 3.5
+      vertex 18.0359 12.3792 3.5
+      vertex 18.2408 11.7038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7668 13.0815 3.5
+      vertex 17.9668 13.0815 3.5
+      vertex 18.0359 12.3792 3.5
     endloop
   endfacet
   facet normal -0.471398 0.881921 0
@@ -8763,6 +9225,34 @@ solid OpenSCAD_Model
       vertex 22.9444 9.75551 3.5
     endloop
   endfacet
+  facet normal -0.634393 0.773011 0
+    outer loop
+      vertex 24.1123 10.5359 3.5
+      vertex 23.5668 10.0882 10
+      vertex 24.1123 10.5359 10
+    endloop
+  endfacet
+  facet normal -0.634393 0.773011 0
+    outer loop
+      vertex 23.5668 10.0882 10
+      vertex 24.1123 10.5359 3.5
+      vertex 23.5668 10.0882 3.5
+    endloop
+  endfacet
+  facet normal 0.95694 -0.290284 0
+    outer loop
+      vertex 18.0359 13.7838 10
+      vertex 18.2408 14.4591 3.5
+      vertex 18.2408 14.4591 10
+    endloop
+  endfacet
+  facet normal 0.95694 -0.290284 0
+    outer loop
+      vertex 18.2408 14.4591 3.5
+      vertex 18.0359 13.7838 10
+      vertex 18.0359 13.7838 3.5
+    endloop
+  endfacet
   facet normal 0.0980169 0.995185 -0
     outer loop
       vertex 21.5668 9.48148 3.5
@@ -8777,32 +9267,18 @@ solid OpenSCAD_Model
       vertex 20.8644 9.55065 3.5
     endloop
   endfacet
-  facet normal -0.77301 -0.634394 0
+  facet normal 0.881921 -0.471397 0
     outer loop
-      vertex 24.56 15.0815 3.5
-      vertex 24.1123 15.6271 10
-      vertex 24.1123 15.6271 3.5
+      vertex 18.2408 14.4591 10
+      vertex 18.5735 15.0815 3.5
+      vertex 18.5735 15.0815 10
     endloop
   endfacet
-  facet normal -0.77301 -0.634394 0
+  facet normal 0.881921 -0.471397 0
     outer loop
-      vertex 24.1123 15.6271 10
-      vertex 24.56 15.0815 3.5
-      vertex 24.56 15.0815 10
-    endloop
-  endfacet
-  facet normal -0.290283 0.956941 0
-    outer loop
-      vertex 22.9444 9.75551 3.5
-      vertex 22.2691 9.55065 10
-      vertex 22.9444 9.75551 10
-    endloop
-  endfacet
-  facet normal -0.290283 0.956941 0
-    outer loop
-      vertex 22.2691 9.55065 10
-      vertex 22.9444 9.75551 3.5
-      vertex 22.2691 9.55065 3.5
+      vertex 18.5735 15.0815 3.5
+      vertex 18.2408 14.4591 10
+      vertex 18.2408 14.4591 3.5
     endloop
   endfacet
   facet normal 0.77301 -0.634394 0
@@ -8819,20 +9295,6 @@ solid OpenSCAD_Model
       vertex 18.5735 15.0815 3.5
     endloop
   endfacet
-  facet normal 0.95694 -0.290284 0
-    outer loop
-      vertex 18.0359 13.7838 10
-      vertex 18.2408 14.4591 3.5
-      vertex 18.2408 14.4591 10
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290284 0
-    outer loop
-      vertex 18.2408 14.4591 3.5
-      vertex 18.0359 13.7838 10
-      vertex 18.0359 13.7838 3.5
-    endloop
-  endfacet
   facet normal 0.290284 0.956941 -0
     outer loop
       vertex 20.8644 9.55065 3.5
@@ -8847,494 +9309,18 @@ solid OpenSCAD_Model
       vertex 20.1891 9.75551 3.5
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
+  facet normal 0.471397 0.881921 -0
     outer loop
-      vertex 19.0212 10.5359 10
-      vertex 18.5735 11.0814 3.5
-      vertex 18.5735 11.0814 10
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex 18.5735 11.0814 3.5
-      vertex 19.0212 10.5359 10
-      vertex 19.0212 10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 -0
-    outer loop
-      vertex 19.5667 10.0882 3.5
-      vertex 19.0212 10.5359 10
+      vertex 20.1891 9.75551 3.5
       vertex 19.5667 10.0882 10
+      vertex 20.1891 9.75551 10
     endloop
   endfacet
-  facet normal 0.634394 0.77301 0
+  facet normal 0.471397 0.881921 0
     outer loop
-      vertex 19.0212 10.5359 10
-      vertex 19.5667 10.0882 3.5
-      vertex 19.0212 10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.3668 13.0815 3.5
-      vertex 25.1668 13.0815 3.5
-      vertex 25.0976 13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.3322 13.4326 3.5
-      vertex 25.0976 13.7838 3.5
-      vertex 24.8927 14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.1668 13.0815 3.5
-      vertex 23.3668 13.0815 3.5
-      vertex 25.0976 12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2297 13.7703 3.5
-      vertex 24.8927 14.4591 3.5
-      vertex 24.56 15.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.3322 12.7303 3.5
-      vertex 25.0976 12.3792 3.5
-      vertex 23.3668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.0634 14.0815 3.5
-      vertex 24.56 15.0815 3.5
-      vertex 24.1123 15.6271 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.0976 12.3792 3.5
-      vertex 23.3322 12.7303 3.5
-      vertex 24.8927 11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.8395 14.3543 3.5
-      vertex 24.1123 15.6271 3.5
-      vertex 23.5668 16.0748 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.2297 12.3926 3.5
-      vertex 24.8927 11.7038 3.5
-      vertex 23.3322 12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8927 11.7038 3.5
-      vertex 23.2297 12.3926 3.5
-      vertex 24.56 11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.0976 13.7838 3.5
-      vertex 23.3322 13.4326 3.5
-      vertex 23.3668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8927 14.4591 3.5
-      vertex 23.2297 13.7703 3.5
-      vertex 23.3322 13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 15.0815 3.5
-      vertex 23.0634 14.0815 3.5
-      vertex 23.2297 13.7703 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.5668 14.5781 3.5
-      vertex 23.5668 16.0748 3.5
-      vertex 22.9444 16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 15.6271 3.5
-      vertex 22.8395 14.3543 3.5
-      vertex 23.0634 14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 16.0748 3.5
-      vertex 22.5668 14.5781 3.5
-      vertex 22.8395 14.3543 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2556 14.7445 3.5
-      vertex 22.9444 16.4074 3.5
-      vertex 22.2691 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 16.4074 3.5
-      vertex 22.2556 14.7445 3.5
-      vertex 22.5668 14.5781 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2691 16.6123 3.5
-      vertex 21.9179 14.8469 3.5
-      vertex 22.2556 14.7445 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 16.6815 3.5
-      vertex 21.9179 14.8469 3.5
-      vertex 22.2691 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 16.6815 3.5
-      vertex 21.5668 14.8815 3.5
-      vertex 21.9179 14.8469 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 16.6815 3.5
-      vertex 21.2156 14.8469 3.5
-      vertex 21.5668 14.8815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.8644 16.6123 3.5
-      vertex 21.2156 14.8469 3.5
-      vertex 21.5668 16.6815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 14.8469 3.5
-      vertex 20.8644 16.6123 3.5
-      vertex 20.8779 14.7445 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.1891 16.4074 3.5
-      vertex 20.8779 14.7445 3.5
-      vertex 20.8644 16.6123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8779 14.7445 3.5
-      vertex 20.1891 16.4074 3.5
-      vertex 20.5667 14.5781 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.5667 16.0748 3.5
-      vertex 20.5667 14.5781 3.5
-      vertex 20.1891 16.4074 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.5667 14.5781 3.5
-      vertex 19.5667 16.0748 3.5
-      vertex 20.294 14.3543 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.0212 15.6271 3.5
-      vertex 20.294 14.3543 3.5
-      vertex 19.5667 16.0748 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.294 14.3543 3.5
-      vertex 19.0212 15.6271 3.5
-      vertex 20.0701 14.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.0701 14.0815 3.5
-      vertex 18.5735 15.0815 3.5
-      vertex 19.9038 13.7703 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.5735 15.0815 3.5
-      vertex 20.0701 14.0815 3.5
-      vertex 19.0212 15.6271 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.0634 12.0814 3.5
-      vertex 24.56 11.0814 3.5
-      vertex 23.2297 12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 11.0814 3.5
-      vertex 23.0634 12.0814 3.5
-      vertex 24.1123 10.5359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.8395 11.8087 3.5
-      vertex 24.1123 10.5359 3.5
-      vertex 23.0634 12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 10.5359 3.5
-      vertex 22.8395 11.8087 3.5
-      vertex 23.5668 10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.5668 11.5848 3.5
-      vertex 23.5668 10.0882 3.5
-      vertex 22.8395 11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 10.0882 3.5
-      vertex 22.5668 11.5848 3.5
-      vertex 22.9444 9.75551 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.2556 11.4185 3.5
-      vertex 22.9444 9.75551 3.5
-      vertex 22.5668 11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 9.75551 3.5
-      vertex 22.2556 11.4185 3.5
-      vertex 22.2691 9.55065 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.9179 11.3161 3.5
-      vertex 22.2691 9.55065 3.5
-      vertex 22.2556 11.4185 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.5668 11.2815 3.5
-      vertex 22.2691 9.55065 3.5
-      vertex 21.9179 11.3161 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 11.2815 3.5
-      vertex 21.5668 9.48148 3.5
-      vertex 22.2691 9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 11.3161 3.5
-      vertex 21.5668 9.48148 3.5
-      vertex 21.5668 11.2815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 9.55065 3.5
-      vertex 21.2156 11.3161 3.5
-      vertex 20.8779 11.4185 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.2156 11.3161 3.5
-      vertex 20.8644 9.55065 3.5
-      vertex 21.5668 9.48148 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
+      vertex 19.5667 10.0882 10
       vertex 20.1891 9.75551 3.5
-      vertex 20.8779 11.4185 3.5
-      vertex 20.5667 11.5848 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
       vertex 19.5667 10.0882 3.5
-      vertex 20.5667 11.5848 3.5
-      vertex 20.294 11.8087 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8779 11.4185 3.5
-      vertex 20.1891 9.75551 3.5
-      vertex 20.8644 9.55065 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 10.5359 3.5
-      vertex 20.294 11.8087 3.5
-      vertex 20.0701 12.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 11.0814 3.5
-      vertex 20.0701 12.0814 3.5
-      vertex 19.9038 12.3926 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 11.7038 3.5
-      vertex 19.9038 12.3926 3.5
-      vertex 19.8013 12.7303 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.5667 11.5848 3.5
-      vertex 19.5667 10.0882 3.5
-      vertex 20.1891 9.75551 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 12.3792 3.5
-      vertex 19.8013 12.7303 3.5
-      vertex 19.7668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.2408 14.4591 3.5
-      vertex 19.9038 13.7703 3.5
-      vertex 18.5735 15.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.9038 13.7703 3.5
-      vertex 18.2408 14.4591 3.5
-      vertex 19.8013 13.4326 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.294 11.8087 3.5
-      vertex 19.0212 10.5359 3.5
-      vertex 19.5667 10.0882 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.0359 13.7838 3.5
-      vertex 19.8013 13.4326 3.5
-      vertex 18.2408 14.4591 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.0701 12.0814 3.5
-      vertex 18.5735 11.0814 3.5
-      vertex 19.0212 10.5359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8013 13.4326 3.5
-      vertex 18.0359 13.7838 3.5
-      vertex 19.7668 13.0815 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.9038 12.3926 3.5
-      vertex 18.2408 11.7038 3.5
-      vertex 18.5735 11.0814 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9668 13.0815 3.5
-      vertex 19.7668 13.0815 3.5
-      vertex 18.0359 13.7838 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8013 12.7303 3.5
-      vertex 18.0359 12.3792 3.5
-      vertex 18.2408 11.7038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.7668 13.0815 3.5
-      vertex 17.9668 13.0815 3.5
-      vertex 18.0359 12.3792 3.5
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex 18.2408 14.4591 10
-      vertex 18.5735 15.0815 3.5
-      vertex 18.5735 15.0815 10
-    endloop
-  endfacet
-  facet normal 0.881921 -0.471397 0
-    outer loop
-      vertex 18.5735 15.0815 3.5
-      vertex 18.2408 14.4591 10
-      vertex 18.2408 14.4591 3.5
     endloop
   endfacet
   facet normal -0.0980171 0.995185 0
@@ -9377,6 +9363,20 @@ solid OpenSCAD_Model
       vertex 18.2408 11.7038 3.5
       vertex 18.5735 11.0814 10
       vertex 18.5735 11.0814 3.5
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 19.0212 10.5359 10
+      vertex 18.5735 11.0814 3.5
+      vertex 18.5735 11.0814 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 18.5735 11.0814 3.5
+      vertex 19.0212 10.5359 10
+      vertex 19.0212 10.5359 3.5
     endloop
   endfacet
   facet normal 0.995185 -0.0980157 0
@@ -9855,18 +9855,18 @@ solid OpenSCAD_Model
       vertex 12.3926 19.9038 0
     endloop
   endfacet
-  facet normal 0.290285 -0.95694 0
+  facet normal 0.634394 -0.77301 0
     outer loop
-      vertex 11.7038 24.8927 3.5
-      vertex 12.3792 25.0976 10
-      vertex 11.7038 24.8927 10
+      vertex 10.5359 24.1123 3.5
+      vertex 11.0814 24.56 10
+      vertex 10.5359 24.1123 10
     endloop
   endfacet
-  facet normal 0.290285 -0.95694 0
+  facet normal 0.634394 -0.77301 0
     outer loop
-      vertex 12.3792 25.0976 10
-      vertex 11.7038 24.8927 3.5
-      vertex 12.3792 25.0976 3.5
+      vertex 11.0814 24.56 10
+      vertex 10.5359 24.1123 3.5
+      vertex 11.0814 24.56 3.5
     endloop
   endfacet
   facet normal -0.773009 0.634395 0
@@ -9881,6 +9881,118 @@ solid OpenSCAD_Model
       vertex 16.0748 19.5667 10
       vertex 15.6271 19.0212 3.5
       vertex 15.6271 19.0212 10
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex 16.0748 23.5668 3.5
+      vertex 15.6271 24.1123 10
+      vertex 15.6271 24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0.77301 -0.634394 0
+    outer loop
+      vertex 15.6271 24.1123 10
+      vertex 16.0748 23.5668 3.5
+      vertex 16.0748 23.5668 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 10.5359 19.0212 10
+      vertex 10.0882 19.5667 3.5
+      vertex 10.0882 19.5667 10
+    endloop
+  endfacet
+  facet normal 0.77301 0.634394 0
+    outer loop
+      vertex 10.0882 19.5667 3.5
+      vertex 10.5359 19.0212 10
+      vertex 10.5359 19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0.0980157 -0.995185 0
+    outer loop
+      vertex 13.0815 25.1668 3.5
+      vertex 13.7838 25.0976 10
+      vertex 13.0815 25.1668 10
+    endloop
+  endfacet
+  facet normal -0.0980157 -0.995185 -0
+    outer loop
+      vertex 13.7838 25.0976 10
+      vertex 13.0815 25.1668 3.5
+      vertex 13.7838 25.0976 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980182 0
+    outer loop
+      vertex 16.6123 20.8644 3.5
+      vertex 16.6815 21.5668 10
+      vertex 16.6815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980182 0
+    outer loop
+      vertex 16.6815 21.5668 10
+      vertex 16.6123 20.8644 3.5
+      vertex 16.6123 20.8644 10
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290284 0
+    outer loop
+      vertex 16.6123 22.2691 3.5
+      vertex 16.4074 22.9444 10
+      vertex 16.4074 22.9444 3.5
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290284 0
+    outer loop
+      vertex 16.4074 22.9444 10
+      vertex 16.6123 22.2691 3.5
+      vertex 16.6123 22.2691 10
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290283 0
+    outer loop
+      vertex 9.55065 22.2691 10
+      vertex 9.75551 22.9444 3.5
+      vertex 9.75551 22.9444 10
+    endloop
+  endfacet
+  facet normal 0.956941 -0.290283 0
+    outer loop
+      vertex 9.75551 22.9444 3.5
+      vertex 9.55065 22.2691 10
+      vertex 9.55065 22.2691 3.5
+    endloop
+  endfacet
+  facet normal 0.290285 -0.95694 0
+    outer loop
+      vertex 11.7038 24.8927 3.5
+      vertex 12.3792 25.0976 10
+      vertex 11.7038 24.8927 10
+    endloop
+  endfacet
+  facet normal 0.290285 -0.95694 0
+    outer loop
+      vertex 12.3792 25.0976 10
+      vertex 11.7038 24.8927 3.5
+      vertex 12.3792 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0.471397 -0.881921 0
+    outer loop
+      vertex 11.0814 24.56 3.5
+      vertex 11.7038 24.8927 10
+      vertex 11.0814 24.56 10
+    endloop
+  endfacet
+  facet normal 0.471397 -0.881921 0
+    outer loop
+      vertex 11.7038 24.8927 10
+      vertex 11.0814 24.56 3.5
+      vertex 11.7038 24.8927 3.5
     endloop
   endfacet
   facet normal 0.0980157 -0.995185 0
@@ -9911,102 +10023,18 @@ solid OpenSCAD_Model
       vertex 15.0815 24.56 3.5
     endloop
   endfacet
-  facet normal -0.956941 -0.290284 0
+  facet normal -0.634394 -0.77301 0
     outer loop
-      vertex 16.6123 22.2691 3.5
-      vertex 16.4074 22.9444 10
-      vertex 16.4074 22.9444 3.5
-    endloop
-  endfacet
-  facet normal -0.956941 -0.290284 0
-    outer loop
-      vertex 16.4074 22.9444 10
-      vertex 16.6123 22.2691 3.5
-      vertex 16.6123 22.2691 10
-    endloop
-  endfacet
-  facet normal -0.881922 0.471395 0
-    outer loop
-      vertex 16.0748 19.5667 3.5
-      vertex 16.4074 20.1891 10
-      vertex 16.4074 20.1891 3.5
-    endloop
-  endfacet
-  facet normal -0.881922 0.471395 0
-    outer loop
-      vertex 16.4074 20.1891 10
-      vertex 16.0748 19.5667 3.5
-      vertex 16.0748 19.5667 10
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 10.0882 23.5668 10
-      vertex 10.5359 24.1123 3.5
-      vertex 10.5359 24.1123 10
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 10.5359 24.1123 3.5
-      vertex 10.0882 23.5668 10
-      vertex 10.0882 23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0.881921 0.471397 0
-    outer loop
-      vertex 10.0882 19.5667 10
-      vertex 9.75551 20.1891 3.5
-      vertex 9.75551 20.1891 10
-    endloop
-  endfacet
-  facet normal 0.881921 0.471397 0
-    outer loop
-      vertex 9.75551 20.1891 3.5
-      vertex 10.0882 19.5667 10
-      vertex 10.0882 19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex 11.0814 24.56 3.5
-      vertex 11.7038 24.8927 10
-      vertex 11.0814 24.56 10
-    endloop
-  endfacet
-  facet normal 0.471397 -0.881921 0
-    outer loop
-      vertex 11.7038 24.8927 10
-      vertex 11.0814 24.56 3.5
-      vertex 11.7038 24.8927 3.5
-    endloop
-  endfacet
-  facet normal -0.0980157 -0.995185 0
-    outer loop
-      vertex 13.0815 25.1668 3.5
-      vertex 13.7838 25.0976 10
-      vertex 13.0815 25.1668 10
-    endloop
-  endfacet
-  facet normal -0.0980157 -0.995185 -0
-    outer loop
-      vertex 13.7838 25.0976 10
-      vertex 13.0815 25.1668 3.5
-      vertex 13.7838 25.0976 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex 16.0748 23.5668 3.5
+      vertex 15.0815 24.56 3.5
       vertex 15.6271 24.1123 10
+      vertex 15.0815 24.56 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.77301 -0
+    outer loop
+      vertex 15.6271 24.1123 10
+      vertex 15.0815 24.56 3.5
       vertex 15.6271 24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0.77301 -0.634394 0
-    outer loop
-      vertex 15.6271 24.1123 10
-      vertex 16.0748 23.5668 3.5
-      vertex 16.0748 23.5668 10
     endloop
   endfacet
   facet normal -0.290284 -0.95694 0
@@ -10037,6 +10065,20 @@ solid OpenSCAD_Model
       vertex 16.4074 20.1891 10
     endloop
   endfacet
+  facet normal -0.881922 0.471395 0
+    outer loop
+      vertex 16.0748 19.5667 3.5
+      vertex 16.4074 20.1891 10
+      vertex 16.4074 20.1891 3.5
+    endloop
+  endfacet
+  facet normal -0.881922 0.471395 0
+    outer loop
+      vertex 16.4074 20.1891 10
+      vertex 16.0748 19.5667 3.5
+      vertex 16.0748 19.5667 10
+    endloop
+  endfacet
   facet normal -0.995185 -0.0980185 0
     outer loop
       vertex 16.6815 21.5668 3.5
@@ -10065,32 +10107,452 @@ solid OpenSCAD_Model
       vertex 16.4074 22.9444 10
     endloop
   endfacet
-  facet normal -0.995185 0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex 16.6123 20.8644 3.5
-      vertex 16.6815 21.5668 10
+      vertex 14.8815 21.5668 3.5
       vertex 16.6815 21.5668 3.5
+      vertex 16.6123 22.2691 3.5
     endloop
   endfacet
-  facet normal -0.995185 0.0980182 0
+  facet normal 0 0 1
     outer loop
-      vertex 16.6815 21.5668 10
+      vertex 14.8469 21.9179 3.5
+      vertex 16.6123 22.2691 3.5
+      vertex 16.4074 22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6815 21.5668 3.5
+      vertex 14.8815 21.5668 3.5
       vertex 16.6123 20.8644 3.5
-      vertex 16.6123 20.8644 10
     endloop
   endfacet
-  facet normal 0.634394 -0.77301 0
+  facet normal 0 0 1
     outer loop
-      vertex 10.5359 24.1123 3.5
-      vertex 11.0814 24.56 10
-      vertex 10.5359 24.1123 10
+      vertex 14.7445 22.2556 3.5
+      vertex 16.4074 22.9444 3.5
+      vertex 16.0748 23.5668 3.5
     endloop
   endfacet
-  facet normal 0.634394 -0.77301 0
+  facet normal -0 0 1
     outer loop
-      vertex 11.0814 24.56 10
-      vertex 10.5359 24.1123 3.5
+      vertex 14.8469 21.2156 3.5
+      vertex 16.6123 20.8644 3.5
+      vertex 14.8815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5781 22.5668 3.5
+      vertex 16.0748 23.5668 3.5
+      vertex 15.6271 24.1123 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 20.8644 3.5
+      vertex 14.8469 21.2156 3.5
+      vertex 16.4074 20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3543 22.8395 3.5
+      vertex 15.6271 24.1123 3.5
+      vertex 15.0815 24.56 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.7445 20.8779 3.5
+      vertex 16.4074 20.1891 3.5
+      vertex 14.8469 21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 20.1891 3.5
+      vertex 14.7445 20.8779 3.5
+      vertex 16.0748 19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 22.2691 3.5
+      vertex 14.8469 21.9179 3.5
+      vertex 14.8815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 22.9444 3.5
+      vertex 14.7445 22.2556 3.5
+      vertex 14.8469 21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 23.5668 3.5
+      vertex 14.5781 22.5668 3.5
+      vertex 14.7445 22.2556 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0815 23.0634 3.5
+      vertex 15.0815 24.56 3.5
+      vertex 14.4591 24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 24.1123 3.5
+      vertex 14.3543 22.8395 3.5
+      vertex 14.5781 22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 24.56 3.5
+      vertex 14.0815 23.0634 3.5
+      vertex 14.3543 22.8395 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7703 23.2297 3.5
+      vertex 14.4591 24.8927 3.5
+      vertex 13.7838 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 24.8927 3.5
+      vertex 13.7703 23.2297 3.5
+      vertex 14.0815 23.0634 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7838 25.0976 3.5
+      vertex 13.4326 23.3322 3.5
+      vertex 13.7703 23.2297 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 25.1668 3.5
+      vertex 13.4326 23.3322 3.5
+      vertex 13.7838 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 25.1668 3.5
+      vertex 13.0815 23.3668 3.5
+      vertex 13.4326 23.3322 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 25.1668 3.5
+      vertex 12.7303 23.3322 3.5
+      vertex 13.0815 23.3668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.3792 25.0976 3.5
+      vertex 12.7303 23.3322 3.5
+      vertex 13.0815 25.1668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 23.3322 3.5
+      vertex 12.3792 25.0976 3.5
+      vertex 12.3926 23.2297 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7038 24.8927 3.5
+      vertex 12.3926 23.2297 3.5
+      vertex 12.3792 25.0976 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3926 23.2297 3.5
+      vertex 11.7038 24.8927 3.5
+      vertex 12.0814 23.0634 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
       vertex 11.0814 24.56 3.5
+      vertex 12.0814 23.0634 3.5
+      vertex 11.7038 24.8927 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0814 23.0634 3.5
+      vertex 11.0814 24.56 3.5
+      vertex 11.8087 22.8395 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.5359 24.1123 3.5
+      vertex 11.8087 22.8395 3.5
+      vertex 11.0814 24.56 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.8087 22.8395 3.5
+      vertex 10.5359 24.1123 3.5
+      vertex 11.5848 22.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5848 22.5668 3.5
+      vertex 10.0882 23.5668 3.5
+      vertex 11.4185 22.2556 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.0882 23.5668 3.5
+      vertex 11.5848 22.5668 3.5
+      vertex 10.5359 24.1123 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5781 20.5667 3.5
+      vertex 16.0748 19.5667 3.5
+      vertex 14.7445 20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 19.5667 3.5
+      vertex 14.5781 20.5667 3.5
+      vertex 15.6271 19.0212 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.3543 20.294 3.5
+      vertex 15.6271 19.0212 3.5
+      vertex 14.5781 20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 19.0212 3.5
+      vertex 14.3543 20.294 3.5
+      vertex 15.0815 18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.0815 20.0701 3.5
+      vertex 15.0815 18.5735 3.5
+      vertex 14.3543 20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 18.5735 3.5
+      vertex 14.0815 20.0701 3.5
+      vertex 14.4591 18.2408 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.7703 19.9038 3.5
+      vertex 14.4591 18.2408 3.5
+      vertex 14.0815 20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 18.2408 3.5
+      vertex 13.7703 19.9038 3.5
+      vertex 13.7838 18.0359 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.4326 19.8013 3.5
+      vertex 13.7838 18.0359 3.5
+      vertex 13.7703 19.9038 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0815 19.7668 3.5
+      vertex 13.7838 18.0359 3.5
+      vertex 13.4326 19.8013 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0815 19.7668 3.5
+      vertex 13.0815 17.9668 3.5
+      vertex 13.7838 18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 19.8013 3.5
+      vertex 13.0815 17.9668 3.5
+      vertex 13.0815 19.7668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 18.0359 3.5
+      vertex 12.7303 19.8013 3.5
+      vertex 12.3926 19.9038 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7303 19.8013 3.5
+      vertex 12.3792 18.0359 3.5
+      vertex 13.0815 17.9668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7038 18.2408 3.5
+      vertex 12.3926 19.9038 3.5
+      vertex 12.0814 20.0701 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0814 18.5735 3.5
+      vertex 12.0814 20.0701 3.5
+      vertex 11.8087 20.294 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3926 19.9038 3.5
+      vertex 11.7038 18.2408 3.5
+      vertex 12.3792 18.0359 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5359 19.0212 3.5
+      vertex 11.8087 20.294 3.5
+      vertex 11.5848 20.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0882 19.5667 3.5
+      vertex 11.5848 20.5667 3.5
+      vertex 11.4185 20.8779 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 20.1891 3.5
+      vertex 11.4185 20.8779 3.5
+      vertex 11.3161 21.2156 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0814 20.0701 3.5
+      vertex 11.0814 18.5735 3.5
+      vertex 11.7038 18.2408 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.55065 20.8644 3.5
+      vertex 11.3161 21.2156 3.5
+      vertex 11.2815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.75551 22.9444 3.5
+      vertex 11.4185 22.2556 3.5
+      vertex 10.0882 23.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4185 22.2556 3.5
+      vertex 9.75551 22.9444 3.5
+      vertex 11.3161 21.9179 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.8087 20.294 3.5
+      vertex 10.5359 19.0212 3.5
+      vertex 11.0814 18.5735 3.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.55065 22.2691 3.5
+      vertex 11.3161 21.9179 3.5
+      vertex 9.75551 22.9444 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5848 20.5667 3.5
+      vertex 10.0882 19.5667 3.5
+      vertex 10.5359 19.0212 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3161 21.9179 3.5
+      vertex 9.55065 22.2691 3.5
+      vertex 11.2815 21.5668 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4185 20.8779 3.5
+      vertex 9.75551 20.1891 3.5
+      vertex 10.0882 19.5667 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.48148 21.5668 3.5
+      vertex 11.2815 21.5668 3.5
+      vertex 9.55065 22.2691 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3161 21.2156 3.5
+      vertex 9.55065 20.8644 3.5
+      vertex 9.75551 20.1891 3.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2815 21.5668 3.5
+      vertex 9.48148 21.5668 3.5
+      vertex 9.55065 20.8644 3.5
     endloop
   endfacet
   facet normal 0.881921 -0.471398 0
@@ -10107,6 +10569,34 @@ solid OpenSCAD_Model
       vertex 9.75551 22.9444 3.5
     endloop
   endfacet
+  facet normal 0.773011 -0.634393 0
+    outer loop
+      vertex 10.0882 23.5668 10
+      vertex 10.5359 24.1123 3.5
+      vertex 10.5359 24.1123 10
+    endloop
+  endfacet
+  facet normal 0.773011 -0.634393 0
+    outer loop
+      vertex 10.5359 24.1123 3.5
+      vertex 10.0882 23.5668 10
+      vertex 10.0882 23.5668 3.5
+    endloop
+  endfacet
+  facet normal -0.290284 0.95694 0
+    outer loop
+      vertex 14.4591 18.2408 3.5
+      vertex 13.7838 18.0359 10
+      vertex 14.4591 18.2408 10
+    endloop
+  endfacet
+  facet normal -0.290284 0.95694 0
+    outer loop
+      vertex 13.7838 18.0359 10
+      vertex 14.4591 18.2408 3.5
+      vertex 13.7838 18.0359 3.5
+    endloop
+  endfacet
   facet normal 0.995185 0.0980169 0
     outer loop
       vertex 9.55065 20.8644 10
@@ -10121,32 +10611,18 @@ solid OpenSCAD_Model
       vertex 9.55065 20.8644 3.5
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 0
+  facet normal -0.471397 0.881921 0
     outer loop
-      vertex 15.0815 24.56 3.5
-      vertex 15.6271 24.1123 10
-      vertex 15.0815 24.56 10
+      vertex 15.0815 18.5735 3.5
+      vertex 14.4591 18.2408 10
+      vertex 15.0815 18.5735 10
     endloop
   endfacet
-  facet normal -0.634394 -0.77301 -0
+  facet normal -0.471397 0.881921 0
     outer loop
-      vertex 15.6271 24.1123 10
-      vertex 15.0815 24.56 3.5
-      vertex 15.6271 24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0.956941 -0.290283 0
-    outer loop
-      vertex 9.55065 22.2691 10
-      vertex 9.75551 22.9444 3.5
-      vertex 9.75551 22.9444 10
-    endloop
-  endfacet
-  facet normal 0.956941 -0.290283 0
-    outer loop
-      vertex 9.75551 22.9444 3.5
-      vertex 9.55065 22.2691 10
-      vertex 9.55065 22.2691 3.5
+      vertex 14.4591 18.2408 10
+      vertex 15.0815 18.5735 3.5
+      vertex 14.4591 18.2408 3.5
     endloop
   endfacet
   facet normal -0.634394 0.77301 0
@@ -10163,20 +10639,6 @@ solid OpenSCAD_Model
       vertex 15.0815 18.5735 3.5
     endloop
   endfacet
-  facet normal -0.290284 0.95694 0
-    outer loop
-      vertex 14.4591 18.2408 3.5
-      vertex 13.7838 18.0359 10
-      vertex 14.4591 18.2408 10
-    endloop
-  endfacet
-  facet normal -0.290284 0.95694 0
-    outer loop
-      vertex 13.7838 18.0359 10
-      vertex 14.4591 18.2408 3.5
-      vertex 13.7838 18.0359 3.5
-    endloop
-  endfacet
   facet normal 0.956941 0.290284 0
     outer loop
       vertex 9.75551 20.1891 10
@@ -10191,494 +10653,18 @@ solid OpenSCAD_Model
       vertex 9.75551 20.1891 3.5
     endloop
   endfacet
-  facet normal 0.634394 0.77301 -0
+  facet normal 0.881921 0.471397 0
     outer loop
-      vertex 11.0814 18.5735 3.5
-      vertex 10.5359 19.0212 10
-      vertex 11.0814 18.5735 10
-    endloop
-  endfacet
-  facet normal 0.634394 0.77301 0
-    outer loop
-      vertex 10.5359 19.0212 10
-      vertex 11.0814 18.5735 3.5
-      vertex 10.5359 19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex 10.5359 19.0212 10
-      vertex 10.0882 19.5667 3.5
       vertex 10.0882 19.5667 10
+      vertex 9.75551 20.1891 3.5
+      vertex 9.75551 20.1891 10
     endloop
   endfacet
-  facet normal 0.77301 0.634394 0
-    outer loop
-      vertex 10.0882 19.5667 3.5
-      vertex 10.5359 19.0212 10
-      vertex 10.5359 19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8815 21.5668 3.5
-      vertex 16.6815 21.5668 3.5
-      vertex 16.6123 22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8469 21.9179 3.5
-      vertex 16.6123 22.2691 3.5
-      vertex 16.4074 22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6815 21.5668 3.5
-      vertex 14.8815 21.5668 3.5
-      vertex 16.6123 20.8644 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7445 22.2556 3.5
-      vertex 16.4074 22.9444 3.5
-      vertex 16.0748 23.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.8469 21.2156 3.5
-      vertex 16.6123 20.8644 3.5
-      vertex 14.8815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5781 22.5668 3.5
-      vertex 16.0748 23.5668 3.5
-      vertex 15.6271 24.1123 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 20.8644 3.5
-      vertex 14.8469 21.2156 3.5
-      vertex 16.4074 20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3543 22.8395 3.5
-      vertex 15.6271 24.1123 3.5
-      vertex 15.0815 24.56 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.7445 20.8779 3.5
-      vertex 16.4074 20.1891 3.5
-      vertex 14.8469 21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 20.1891 3.5
-      vertex 14.7445 20.8779 3.5
-      vertex 16.0748 19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 22.2691 3.5
-      vertex 14.8469 21.9179 3.5
-      vertex 14.8815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 22.9444 3.5
-      vertex 14.7445 22.2556 3.5
-      vertex 14.8469 21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 23.5668 3.5
-      vertex 14.5781 22.5668 3.5
-      vertex 14.7445 22.2556 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0815 23.0634 3.5
-      vertex 15.0815 24.56 3.5
-      vertex 14.4591 24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 24.1123 3.5
-      vertex 14.3543 22.8395 3.5
-      vertex 14.5781 22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 24.56 3.5
-      vertex 14.0815 23.0634 3.5
-      vertex 14.3543 22.8395 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7703 23.2297 3.5
-      vertex 14.4591 24.8927 3.5
-      vertex 13.7838 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 24.8927 3.5
-      vertex 13.7703 23.2297 3.5
-      vertex 14.0815 23.0634 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7838 25.0976 3.5
-      vertex 13.4326 23.3322 3.5
-      vertex 13.7703 23.2297 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 25.1668 3.5
-      vertex 13.4326 23.3322 3.5
-      vertex 13.7838 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 25.1668 3.5
-      vertex 13.0815 23.3668 3.5
-      vertex 13.4326 23.3322 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 25.1668 3.5
-      vertex 12.7303 23.3322 3.5
-      vertex 13.0815 23.3668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.3792 25.0976 3.5
-      vertex 12.7303 23.3322 3.5
-      vertex 13.0815 25.1668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 23.3322 3.5
-      vertex 12.3792 25.0976 3.5
-      vertex 12.3926 23.2297 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7038 24.8927 3.5
-      vertex 12.3926 23.2297 3.5
-      vertex 12.3792 25.0976 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3926 23.2297 3.5
-      vertex 11.7038 24.8927 3.5
-      vertex 12.0814 23.0634 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.0814 24.56 3.5
-      vertex 12.0814 23.0634 3.5
-      vertex 11.7038 24.8927 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0814 23.0634 3.5
-      vertex 11.0814 24.56 3.5
-      vertex 11.8087 22.8395 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.5359 24.1123 3.5
-      vertex 11.8087 22.8395 3.5
-      vertex 11.0814 24.56 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8087 22.8395 3.5
-      vertex 10.5359 24.1123 3.5
-      vertex 11.5848 22.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5848 22.5668 3.5
-      vertex 10.0882 23.5668 3.5
-      vertex 11.4185 22.2556 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.0882 23.5668 3.5
-      vertex 11.5848 22.5668 3.5
-      vertex 10.5359 24.1123 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.5781 20.5667 3.5
-      vertex 16.0748 19.5667 3.5
-      vertex 14.7445 20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 19.5667 3.5
-      vertex 14.5781 20.5667 3.5
-      vertex 15.6271 19.0212 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.3543 20.294 3.5
-      vertex 15.6271 19.0212 3.5
-      vertex 14.5781 20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 19.0212 3.5
-      vertex 14.3543 20.294 3.5
-      vertex 15.0815 18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.0815 20.0701 3.5
-      vertex 15.0815 18.5735 3.5
-      vertex 14.3543 20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 18.5735 3.5
-      vertex 14.0815 20.0701 3.5
-      vertex 14.4591 18.2408 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7703 19.9038 3.5
-      vertex 14.4591 18.2408 3.5
-      vertex 14.0815 20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 18.2408 3.5
-      vertex 13.7703 19.9038 3.5
-      vertex 13.7838 18.0359 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.4326 19.8013 3.5
-      vertex 13.7838 18.0359 3.5
-      vertex 13.7703 19.9038 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0815 19.7668 3.5
-      vertex 13.7838 18.0359 3.5
-      vertex 13.4326 19.8013 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0815 19.7668 3.5
-      vertex 13.0815 17.9668 3.5
-      vertex 13.7838 18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 19.8013 3.5
-      vertex 13.0815 17.9668 3.5
-      vertex 13.0815 19.7668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 18.0359 3.5
-      vertex 12.7303 19.8013 3.5
-      vertex 12.3926 19.9038 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7303 19.8013 3.5
-      vertex 12.3792 18.0359 3.5
-      vertex 13.0815 17.9668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7038 18.2408 3.5
-      vertex 12.3926 19.9038 3.5
-      vertex 12.0814 20.0701 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.0814 18.5735 3.5
-      vertex 12.0814 20.0701 3.5
-      vertex 11.8087 20.294 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3926 19.9038 3.5
-      vertex 11.7038 18.2408 3.5
-      vertex 12.3792 18.0359 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5359 19.0212 3.5
-      vertex 11.8087 20.294 3.5
-      vertex 11.5848 20.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.0882 19.5667 3.5
-      vertex 11.5848 20.5667 3.5
-      vertex 11.4185 20.8779 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
+  facet normal 0.881921 0.471397 0
     outer loop
       vertex 9.75551 20.1891 3.5
-      vertex 11.4185 20.8779 3.5
-      vertex 11.3161 21.2156 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0814 20.0701 3.5
-      vertex 11.0814 18.5735 3.5
-      vertex 11.7038 18.2408 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.55065 20.8644 3.5
-      vertex 11.3161 21.2156 3.5
-      vertex 11.2815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.75551 22.9444 3.5
-      vertex 11.4185 22.2556 3.5
-      vertex 10.0882 23.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.4185 22.2556 3.5
-      vertex 9.75551 22.9444 3.5
-      vertex 11.3161 21.9179 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8087 20.294 3.5
-      vertex 10.5359 19.0212 3.5
-      vertex 11.0814 18.5735 3.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.55065 22.2691 3.5
-      vertex 11.3161 21.9179 3.5
-      vertex 9.75551 22.9444 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5848 20.5667 3.5
+      vertex 10.0882 19.5667 10
       vertex 10.0882 19.5667 3.5
-      vertex 10.5359 19.0212 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.3161 21.9179 3.5
-      vertex 9.55065 22.2691 3.5
-      vertex 11.2815 21.5668 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.4185 20.8779 3.5
-      vertex 9.75551 20.1891 3.5
-      vertex 10.0882 19.5667 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.48148 21.5668 3.5
-      vertex 11.2815 21.5668 3.5
-      vertex 9.55065 22.2691 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.3161 21.2156 3.5
-      vertex 9.55065 20.8644 3.5
-      vertex 9.75551 20.1891 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.2815 21.5668 3.5
-      vertex 9.48148 21.5668 3.5
-      vertex 9.55065 20.8644 3.5
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex 15.0815 18.5735 3.5
-      vertex 14.4591 18.2408 10
-      vertex 15.0815 18.5735 10
-    endloop
-  endfacet
-  facet normal -0.471397 0.881921 0
-    outer loop
-      vertex 14.4591 18.2408 10
-      vertex 15.0815 18.5735 3.5
-      vertex 14.4591 18.2408 3.5
     endloop
   endfacet
   facet normal 0.995185 -0.0980171 0
@@ -10723,6 +10709,20 @@ solid OpenSCAD_Model
       vertex 11.0814 18.5735 3.5
     endloop
   endfacet
+  facet normal 0.634394 0.77301 -0
+    outer loop
+      vertex 11.0814 18.5735 3.5
+      vertex 10.5359 19.0212 10
+      vertex 11.0814 18.5735 10
+    endloop
+  endfacet
+  facet normal 0.634394 0.77301 0
+    outer loop
+      vertex 10.5359 19.0212 10
+      vertex 11.0814 18.5735 3.5
+      vertex 10.5359 19.0212 3.5
+    endloop
+  endfacet
   facet normal -0.0980157 0.995185 0
     outer loop
       vertex 13.7838 18.0359 3.5
@@ -10751,4932 +10751,1852 @@ solid OpenSCAD_Model
       vertex 12.3792 18.0359 3.5
     endloop
   endfacet
-  facet normal -0.634393 -0.773011 0
+  facet normal -0.412705 -0.910865 0
     outer loop
-      vertex -16.5324 18.509 0
-      vertex -16.3165 18.3317 10
-      vertex -16.5324 18.509 10
+      vertex -16.0689 18.4352 0
+      vertex -15.9082 18.3624 10
+      vertex -16.0689 18.4352 10
     endloop
   endfacet
-  facet normal -0.634393 -0.773011 -0
+  facet normal -0.412705 -0.910865 -0
     outer loop
-      vertex -16.3165 18.3317 10
-      vertex -16.5324 18.509 0
-      vertex -16.3165 18.3317 0
+      vertex -15.9082 18.3624 10
+      vertex -16.0689 18.4352 0
+      vertex -15.9082 18.3624 0
     endloop
   endfacet
-  facet normal 0.634393 -0.773011 0
+  facet normal -0.258819 -0.965926 0
     outer loop
-      vertex -18.3317 18.3317 0
-      vertex -18.1158 18.509 10
-      vertex -18.3317 18.3317 10
+      vertex -17.8556 18.9139 0
+      vertex -16.0689 18.4352 10
+      vertex -17.8556 18.9139 10
     endloop
   endfacet
-  facet normal 0.634393 -0.773011 0
+  facet normal -0.258819 -0.965926 -0
     outer loop
-      vertex -18.1158 18.509 10
-      vertex -18.3317 18.3317 0
-      vertex -18.1158 18.509 0
+      vertex -16.0689 18.4352 10
+      vertex -17.8556 18.9139 0
+      vertex -16.0689 18.4352 0
     endloop
   endfacet
-  facet normal -0.0980137 -0.995185 0
+  facet normal -0.986643 -0.162896 0
     outer loop
-      vertex -17.3241 18.7491 0
-      vertex -17.0461 18.7217 10
-      vertex -17.3241 18.7491 10
+      vertex -15.4601 17.6418 0
+      vertex -15.4889 17.8159 10
+      vertex -15.4889 17.8159 0
     endloop
   endfacet
-  facet normal -0.0980137 -0.995185 -0
+  facet normal -0.986643 -0.162896 0
     outer loop
-      vertex -17.0461 18.7217 10
-      vertex -17.3241 18.7491 0
-      vertex -17.0461 18.7217 0
+      vertex -15.4889 17.8159 10
+      vertex -15.4601 17.6418 0
+      vertex -15.4601 17.6418 10
     endloop
   endfacet
-  facet normal 0.995185 -0.0980137 0
+  facet normal -0.0980094 -0.995185 0
     outer loop
-      vertex -18.7491 17.3241 10
-      vertex -18.7217 17.6021 0
-      vertex -18.7217 17.6021 10
+      vertex -18.0312 18.9312 0
+      vertex -17.8556 18.9139 10
+      vertex -18.0312 18.9312 10
     endloop
   endfacet
-  facet normal 0.995185 -0.0980137 0
+  facet normal -0.0980094 -0.995185 -0
     outer loop
-      vertex -18.7217 17.6021 0
-      vertex -18.7491 17.3241 10
-      vertex -18.7491 17.3241 0
+      vertex -17.8556 18.9139 10
+      vertex -18.0312 18.9312 0
+      vertex -17.8556 18.9139 0
     endloop
   endfacet
-  facet normal 0.881923 -0.471393 0
+  facet normal -0.582482 0.812844 0
     outer loop
-      vertex -18.6406 17.8694 10
-      vertex -18.509 18.1158 0
-      vertex -18.509 18.1158 10
+      vertex -16.9895 15.6815 0
+      vertex -17.1329 15.5788 10
+      vertex -16.9895 15.6815 10
     endloop
   endfacet
-  facet normal 0.881923 -0.471393 0
+  facet normal -0.582482 0.812844 0
     outer loop
-      vertex -18.509 18.1158 0
-      vertex -18.6406 17.8694 10
-      vertex -18.6406 17.8694 0
+      vertex -17.1329 15.5788 10
+      vertex -16.9895 15.6815 0
+      vertex -17.1329 15.5788 0
     endloop
   endfacet
-  facet normal -0.995185 -0.098017 0
+  facet normal 0.965926 0.258819 0
     outer loop
-      vertex -15.8991 17.3241 0
-      vertex -15.9265 17.6021 10
-      vertex -15.9265 17.6021 0
+      vertex -18.4352 16.0689 10
+      vertex -18.9139 17.8556 0
+      vertex -18.9139 17.8556 10
     endloop
   endfacet
-  facet normal -0.995185 -0.098017 0
+  facet normal 0.965926 0.258819 0
     outer loop
-      vertex -15.9265 17.6021 10
-      vertex -15.8991 17.3241 0
-      vertex -15.8991 17.3241 10
+      vertex -18.9139 17.8556 0
+      vertex -18.4352 16.0689 10
+      vertex -18.4352 16.0689 0
     endloop
   endfacet
-  facet normal -0.290285 -0.95694 0
+  facet normal -0.707107 0.707107 0
     outer loop
-      vertex -17.0461 18.7217 0
-      vertex -16.7788 18.6406 10
-      vertex -17.0461 18.7217 10
+      vertex -16.9895 15.6815 0
+      vertex -15.6815 16.9895 10
+      vertex -15.6815 16.9895 0
     endloop
   endfacet
-  facet normal -0.290285 -0.95694 -0
+  facet normal -0.707107 0.707107 0
     outer loop
-      vertex -16.7788 18.6406 10
-      vertex -17.0461 18.7217 0
-      vertex -16.7788 18.6406 0
+      vertex -15.6815 16.9895 10
+      vertex -16.9895 15.6815 0
+      vertex -16.9895 15.6815 10
     endloop
   endfacet
-  facet normal -0.471396 -0.881922 0
+  facet normal 0.352251 0.935906 -0
     outer loop
-      vertex -16.7788 18.6406 0
-      vertex -16.5324 18.509 10
-      vertex -16.7788 18.6406 10
+      vertex -17.8159 15.4889 0
+      vertex -17.981 15.551 10
+      vertex -17.8159 15.4889 10
     endloop
   endfacet
-  facet normal -0.471396 -0.881922 -0
+  facet normal 0.352251 0.935906 0
     outer loop
-      vertex -16.5324 18.509 10
-      vertex -16.7788 18.6406 0
-      vertex -16.5324 18.509 0
+      vertex -17.981 15.551 10
+      vertex -17.8159 15.4889 0
+      vertex -17.981 15.551 0
     endloop
   endfacet
-  facet normal 0.290287 -0.95694 0
+  facet normal -0.973877 0.227075 0
     outer loop
-      vertex -17.8694 18.6406 0
-      vertex -17.6021 18.7217 10
-      vertex -17.8694 18.6406 10
+      vertex -15.506 17.2936 0
+      vertex -15.4659 17.4655 10
+      vertex -15.4659 17.4655 0
     endloop
   endfacet
-  facet normal 0.290287 -0.95694 0
+  facet normal -0.973877 0.227075 0
     outer loop
-      vertex -17.6021 18.7217 10
-      vertex -17.8694 18.6406 0
-      vertex -17.6021 18.7217 0
+      vertex -15.4659 17.4655 10
+      vertex -15.506 17.2936 0
+      vertex -15.506 17.2936 10
     endloop
   endfacet
-  facet normal 0.471393 -0.881923 0
+  facet normal -0.812844 0.582482 0
     outer loop
-      vertex -18.1158 18.509 0
-      vertex -17.8694 18.6406 10
-      vertex -18.1158 18.509 10
+      vertex -15.6815 16.9895 0
+      vertex -15.5788 17.1329 10
+      vertex -15.5788 17.1329 0
     endloop
   endfacet
-  facet normal 0.471393 -0.881923 0
+  facet normal -0.812844 0.582482 0
     outer loop
-      vertex -17.8694 18.6406 10
-      vertex -18.1158 18.509 0
-      vertex -17.8694 18.6406 0
+      vertex -15.5788 17.1329 10
+      vertex -15.6815 16.9895 0
+      vertex -15.6815 16.9895 10
     endloop
   endfacet
-  facet normal 0.0980137 -0.995185 0
+  facet normal -0.935906 -0.352251 0
     outer loop
-      vertex -17.6021 18.7217 0
-      vertex -17.3241 18.7491 10
-      vertex -17.6021 18.7217 10
+      vertex -15.4889 17.8159 0
+      vertex -15.551 17.981 10
+      vertex -15.551 17.981 0
     endloop
   endfacet
-  facet normal 0.0980137 -0.995185 0
+  facet normal -0.935906 -0.352251 0
     outer loop
-      vertex -17.3241 18.7491 10
-      vertex -17.6021 18.7217 0
-      vertex -17.3241 18.7491 0
+      vertex -15.551 17.981 10
+      vertex -15.4889 17.8159 0
+      vertex -15.4889 17.8159 10
     endloop
   endfacet
-  facet normal 0.995185 0.0980137 0
+  facet normal -0.729861 -0.683596 0
     outer loop
-      vertex -18.7217 17.0461 10
-      vertex -18.7491 17.3241 0
-      vertex -18.7491 17.3241 10
+      vertex -15.6442 18.1308 0
+      vertex -15.7648 18.2596 10
+      vertex -15.7648 18.2596 0
     endloop
   endfacet
-  facet normal 0.995185 0.0980137 0
+  facet normal -0.729861 -0.683596 0
     outer loop
-      vertex -18.7491 17.3241 0
-      vertex -18.7217 17.0461 10
-      vertex -18.7217 17.0461 0
+      vertex -15.7648 18.2596 10
+      vertex -15.6442 18.1308 0
+      vertex -15.6442 18.1308 10
     endloop
   endfacet
-  facet normal 0.881922 0.471396 0
+  facet normal -0.58248 -0.812845 0
     outer loop
-      vertex -18.509 16.5324 10
-      vertex -18.6406 16.7788 0
-      vertex -18.6406 16.7788 10
+      vertex -15.9082 18.3624 0
+      vertex -15.7648 18.2596 10
+      vertex -15.9082 18.3624 10
     endloop
   endfacet
-  facet normal 0.881922 0.471396 0
+  facet normal -0.58248 -0.812845 -0
     outer loop
-      vertex -18.6406 16.7788 0
-      vertex -18.509 16.5324 10
-      vertex -18.509 16.5324 0
+      vertex -15.7648 18.2596 10
+      vertex -15.9082 18.3624 0
+      vertex -15.7648 18.2596 0
     endloop
   endfacet
-  facet normal 0.95694 -0.290287 0
+  facet normal 0.683596 0.729861 -0
     outer loop
-      vertex -18.7217 17.6021 10
-      vertex -18.6406 17.8694 0
-      vertex -18.6406 17.8694 10
+      vertex -18.1308 15.6442 0
+      vertex -18.2596 15.7648 10
+      vertex -18.1308 15.6442 10
     endloop
   endfacet
-  facet normal 0.95694 -0.290287 0
+  facet normal 0.683596 0.729861 0
     outer loop
-      vertex -18.6406 17.8694 0
-      vertex -18.7217 17.6021 10
-      vertex -18.7217 17.6021 0
+      vertex -18.2596 15.7648 10
+      vertex -18.1308 15.6442 0
+      vertex -18.2596 15.7648 0
     endloop
   endfacet
-  facet normal 0.773011 -0.634393 0
+  facet normal 0.290291 -0.956938 0
     outer loop
-      vertex -18.509 18.1158 10
-      vertex -18.3317 18.3317 0
-      vertex -18.3317 18.3317 10
+      vertex -18.3756 18.8627 0
+      vertex -18.2068 18.9139 10
+      vertex -18.3756 18.8627 10
     endloop
   endfacet
-  facet normal 0.773011 -0.634393 0
+  facet normal 0.290291 -0.956938 0
     outer loop
-      vertex -18.3317 18.3317 0
-      vertex -18.509 18.1158 10
-      vertex -18.509 18.1158 0
+      vertex -18.2068 18.9139 10
+      vertex -18.3756 18.8627 0
+      vertex -18.2068 18.9139 0
     endloop
   endfacet
-  facet normal -0.773011 -0.634393 0
+  facet normal 0.634394 -0.773009 0
     outer loop
-      vertex -16.1393 18.1158 0
-      vertex -16.3165 18.3317 10
-      vertex -16.3165 18.3317 0
+      vertex -18.6676 18.6676 0
+      vertex -18.5312 18.7795 10
+      vertex -18.6676 18.6676 10
     endloop
   endfacet
-  facet normal -0.773011 -0.634393 0
+  facet normal 0.634394 -0.773009 0
     outer loop
-      vertex -16.3165 18.3317 10
-      vertex -16.1393 18.1158 0
-      vertex -16.1393 18.1158 10
+      vertex -18.5312 18.7795 10
+      vertex -18.6676 18.6676 0
+      vertex -18.5312 18.7795 0
     endloop
   endfacet
-  facet normal -0.995185 0.098017 0
+  facet normal 0.471394 -0.881923 0
     outer loop
-      vertex -15.9265 17.0461 0
-      vertex -15.8991 17.3241 10
-      vertex -15.8991 17.3241 0
+      vertex -18.5312 18.7795 0
+      vertex -18.3756 18.8627 10
+      vertex -18.5312 18.7795 10
     endloop
   endfacet
-  facet normal -0.995185 0.098017 0
+  facet normal 0.471394 -0.881923 0
     outer loop
-      vertex -15.8991 17.3241 10
-      vertex -15.9265 17.0461 0
-      vertex -15.9265 17.0461 10
+      vertex -18.3756 18.8627 10
+      vertex -18.5312 18.7795 0
+      vertex -18.3756 18.8627 0
     endloop
   endfacet
-  facet normal -0.098017 0.995185 0
+  facet normal 0.773009 -0.634394 0
     outer loop
-      vertex -17.0461 15.9265 0
-      vertex -17.3241 15.8991 10
-      vertex -17.0461 15.9265 10
+      vertex -18.7795 18.5312 10
+      vertex -18.6676 18.6676 0
+      vertex -18.6676 18.6676 10
     endloop
   endfacet
-  facet normal -0.098017 0.995185 0
+  facet normal 0.773009 -0.634394 0
     outer loop
-      vertex -17.3241 15.8991 10
-      vertex -17.0461 15.9265 0
-      vertex -17.3241 15.8991 0
+      vertex -18.6676 18.6676 0
+      vertex -18.7795 18.5312 10
+      vertex -18.7795 18.5312 0
     endloop
   endfacet
-  facet normal -0.471396 0.881922 0
+  facet normal 0.881923 -0.471394 0
     outer loop
-      vertex -16.5324 16.1393 0
-      vertex -16.7788 16.0076 10
-      vertex -16.5324 16.1393 10
+      vertex -18.8627 18.3756 10
+      vertex -18.7795 18.5312 0
+      vertex -18.7795 18.5312 10
     endloop
   endfacet
-  facet normal -0.471396 0.881922 0
+  facet normal 0.881923 -0.471394 0
     outer loop
-      vertex -16.7788 16.0076 10
-      vertex -16.5324 16.1393 0
-      vertex -16.7788 16.0076 0
+      vertex -18.7795 18.5312 0
+      vertex -18.8627 18.3756 10
+      vertex -18.8627 18.3756 0
     endloop
   endfacet
-  facet normal 0.290287 0.95694 -0
+  facet normal 0.162896 0.986643 -0
     outer loop
-      vertex -17.6021 15.9265 0
-      vertex -17.8694 16.0076 10
-      vertex -17.6021 15.9265 10
+      vertex -17.6418 15.4601 0
+      vertex -17.8159 15.4889 10
+      vertex -17.6418 15.4601 10
     endloop
   endfacet
-  facet normal 0.290287 0.95694 0
+  facet normal 0.162896 0.986643 0
     outer loop
-      vertex -17.8694 16.0076 10
-      vertex -17.6021 15.9265 0
-      vertex -17.8694 16.0076 0
+      vertex -17.8159 15.4889 10
+      vertex -17.6418 15.4601 0
+      vertex -17.8159 15.4889 0
     endloop
   endfacet
-  facet normal 0.634393 0.773011 -0
+  facet normal 0.528066 0.849204 -0
     outer loop
-      vertex -18.1158 16.1393 0
-      vertex -18.3317 16.3165 10
-      vertex -18.1158 16.1393 10
+      vertex -17.981 15.551 0
+      vertex -18.1308 15.6442 10
+      vertex -17.981 15.551 10
     endloop
   endfacet
-  facet normal 0.634393 0.773011 0
+  facet normal 0.528066 0.849204 0
     outer loop
-      vertex -18.3317 16.3165 10
-      vertex -18.1158 16.1393 0
-      vertex -18.3317 16.3165 0
+      vertex -18.1308 15.6442 10
+      vertex -17.981 15.551 0
+      vertex -18.1308 15.6442 0
     endloop
   endfacet
-  facet normal 0.95694 0.290285 0
+  facet normal -0.412708 0.910863 0
     outer loop
-      vertex -18.6406 16.7788 10
-      vertex -18.7217 17.0461 0
-      vertex -18.7217 17.0461 10
+      vertex -17.1329 15.5788 0
+      vertex -17.2936 15.506 10
+      vertex -17.1329 15.5788 10
     endloop
   endfacet
-  facet normal 0.95694 0.290285 0
+  facet normal -0.412708 0.910863 0
     outer loop
-      vertex -18.7217 17.0461 0
-      vertex -18.6406 16.7788 10
-      vertex -18.6406 16.7788 0
+      vertex -17.2936 15.506 10
+      vertex -17.1329 15.5788 0
+      vertex -17.2936 15.506 0
     endloop
   endfacet
-  facet normal 0.773011 0.634393 0
+  facet normal -0.0327187 0.999465 0
     outer loop
-      vertex -18.3317 16.3165 10
-      vertex -18.509 16.5324 0
-      vertex -18.509 16.5324 10
+      vertex -17.4655 15.4659 0
+      vertex -17.6418 15.4601 10
+      vertex -17.4655 15.4659 10
     endloop
   endfacet
-  facet normal 0.773011 0.634393 0
+  facet normal -0.0327187 0.999465 0
     outer loop
-      vertex -18.509 16.5324 0
-      vertex -18.3317 16.3165 10
-      vertex -18.3317 16.3165 0
+      vertex -17.6418 15.4601 10
+      vertex -17.4655 15.4659 0
+      vertex -17.6418 15.4601 0
     endloop
   endfacet
-  facet normal -0.773011 0.634393 0
+  facet normal -0.910863 0.412708 0
     outer loop
-      vertex -16.3165 16.3165 0
-      vertex -16.1393 16.5324 10
-      vertex -16.1393 16.5324 0
+      vertex -15.5788 17.1329 0
+      vertex -15.506 17.2936 10
+      vertex -15.506 17.2936 0
     endloop
   endfacet
-  facet normal -0.773011 0.634393 0
+  facet normal -0.910863 0.412708 0
     outer loop
-      vertex -16.1393 16.5324 10
-      vertex -16.3165 16.3165 0
-      vertex -16.3165 16.3165 10
+      vertex -15.506 17.2936 10
+      vertex -15.5788 17.1329 0
+      vertex -15.5788 17.1329 10
     endloop
   endfacet
-  facet normal -0.95694 0.290285 0
+  facet normal -0.999465 0.0327187 0
     outer loop
-      vertex -16.0076 16.7788 0
-      vertex -15.9265 17.0461 10
-      vertex -15.9265 17.0461 0
+      vertex -15.4659 17.4655 0
+      vertex -15.4601 17.6418 10
+      vertex -15.4601 17.6418 0
     endloop
   endfacet
-  facet normal -0.95694 0.290285 0
+  facet normal -0.999465 0.0327187 0
     outer loop
-      vertex -15.9265 17.0461 10
-      vertex -16.0076 16.7788 0
-      vertex -16.0076 16.7788 10
+      vertex -15.4601 17.6418 10
+      vertex -15.4659 17.4655 0
+      vertex -15.4659 17.4655 10
     endloop
   endfacet
-  facet normal -0.881923 -0.471393 0
+  facet normal -0.849204 -0.528066 0
     outer loop
-      vertex -16.0076 17.8694 0
-      vertex -16.1393 18.1158 10
-      vertex -16.1393 18.1158 0
+      vertex -15.551 17.981 0
+      vertex -15.6442 18.1308 10
+      vertex -15.6442 18.1308 0
     endloop
   endfacet
-  facet normal -0.881923 -0.471393 0
+  facet normal -0.849204 -0.528066 0
     outer loop
-      vertex -16.1393 18.1158 10
-      vertex -16.0076 17.8694 0
-      vertex -16.0076 17.8694 10
+      vertex -15.6442 18.1308 10
+      vertex -15.551 17.981 0
+      vertex -15.551 17.981 10
     endloop
   endfacet
-  facet normal -0.95694 -0.290287 0
+  facet normal 0.0980104 -0.995185 0
     outer loop
-      vertex -15.9265 17.6021 0
-      vertex -16.0076 17.8694 10
-      vertex -16.0076 17.8694 0
+      vertex -18.2068 18.9139 0
+      vertex -18.0312 18.9312 10
+      vertex -18.2068 18.9139 10
     endloop
   endfacet
-  facet normal -0.95694 -0.290287 0
+  facet normal 0.0980104 -0.995185 0
     outer loop
-      vertex -16.0076 17.8694 10
-      vertex -15.9265 17.6021 0
-      vertex -15.9265 17.6021 10
+      vertex -18.0312 18.9312 10
+      vertex -18.2068 18.9139 0
+      vertex -18.0312 18.9312 0
     endloop
   endfacet
-  facet normal -0.290285 0.95694 0
+  facet normal 0.910865 0.412705 0
     outer loop
-      vertex -16.7788 16.0076 0
-      vertex -17.0461 15.9265 10
-      vertex -16.7788 16.0076 10
+      vertex -18.3624 15.9082 10
+      vertex -18.4352 16.0689 0
+      vertex -18.4352 16.0689 10
     endloop
   endfacet
-  facet normal -0.290285 0.95694 0
+  facet normal 0.910865 0.412705 0
     outer loop
-      vertex -17.0461 15.9265 10
-      vertex -16.7788 16.0076 0
-      vertex -17.0461 15.9265 0
+      vertex -18.4352 16.0689 0
+      vertex -18.3624 15.9082 10
+      vertex -18.3624 15.9082 0
     endloop
   endfacet
-  facet normal -0.634393 0.773011 0
+  facet normal 0.995185 -0.0980104 0
     outer loop
-      vertex -16.3165 16.3165 0
-      vertex -16.5324 16.1393 10
-      vertex -16.3165 16.3165 10
+      vertex -18.9312 18.0312 10
+      vertex -18.9139 18.2068 0
+      vertex -18.9139 18.2068 10
     endloop
   endfacet
-  facet normal -0.634393 0.773011 0
+  facet normal 0.995185 -0.0980104 0
     outer loop
-      vertex -16.5324 16.1393 10
-      vertex -16.3165 16.3165 0
-      vertex -16.5324 16.1393 0
+      vertex -18.9139 18.2068 0
+      vertex -18.9312 18.0312 10
+      vertex -18.9312 18.0312 0
     endloop
   endfacet
-  facet normal 0.098017 0.995185 -0
+  facet normal 0.995185 0.0980094 0
     outer loop
-      vertex -17.3241 15.8991 0
-      vertex -17.6021 15.9265 10
-      vertex -17.3241 15.8991 10
+      vertex -18.9139 17.8556 10
+      vertex -18.9312 18.0312 0
+      vertex -18.9312 18.0312 10
     endloop
   endfacet
-  facet normal 0.098017 0.995185 0
+  facet normal 0.995185 0.0980094 0
     outer loop
-      vertex -17.6021 15.9265 10
-      vertex -17.3241 15.8991 0
-      vertex -17.6021 15.9265 0
+      vertex -18.9312 18.0312 0
+      vertex -18.9139 17.8556 10
+      vertex -18.9139 17.8556 0
     endloop
   endfacet
-  facet normal 0.471393 0.881923 -0
+  facet normal 0.956938 -0.290291 0
     outer loop
-      vertex -17.8694 16.0076 0
-      vertex -18.1158 16.1393 10
-      vertex -17.8694 16.0076 10
+      vertex -18.9139 18.2068 10
+      vertex -18.8627 18.3756 0
+      vertex -18.8627 18.3756 10
     endloop
   endfacet
-  facet normal 0.471393 0.881923 0
+  facet normal 0.956938 -0.290291 0
     outer loop
-      vertex -18.1158 16.1393 10
-      vertex -17.8694 16.0076 0
-      vertex -18.1158 16.1393 0
+      vertex -18.8627 18.3756 0
+      vertex -18.9139 18.2068 10
+      vertex -18.9139 18.2068 0
     endloop
   endfacet
-  facet normal -0.881922 0.471396 0
+  facet normal -0.227075 0.973877 0
     outer loop
-      vertex -16.1393 16.5324 0
-      vertex -16.0076 16.7788 10
-      vertex -16.0076 16.7788 0
+      vertex -17.2936 15.506 0
+      vertex -17.4655 15.4659 10
+      vertex -17.2936 15.506 10
     endloop
   endfacet
-  facet normal -0.881922 0.471396 0
+  facet normal -0.227075 0.973877 0
     outer loop
-      vertex -16.0076 16.7788 10
-      vertex -16.1393 16.5324 0
-      vertex -16.1393 16.5324 10
+      vertex -17.4655 15.4659 10
+      vertex -17.2936 15.506 0
+      vertex -17.4655 15.4659 0
     endloop
   endfacet
-  facet normal 0.773011 -0.634393 0
+  facet normal 0.812845 0.58248 0
     outer loop
-      vertex -18.509 -16.5324 10
-      vertex -18.3317 -16.3165 0
-      vertex -18.3317 -16.3165 10
+      vertex -18.2596 15.7648 10
+      vertex -18.3624 15.9082 0
+      vertex -18.3624 15.9082 10
     endloop
   endfacet
-  facet normal 0.773011 -0.634393 0
+  facet normal 0.812845 0.58248 0
     outer loop
-      vertex -18.3317 -16.3165 0
-      vertex -18.509 -16.5324 10
-      vertex -18.509 -16.5324 0
+      vertex -18.3624 15.9082 0
+      vertex -18.2596 15.7648 10
+      vertex -18.2596 15.7648 0
     endloop
   endfacet
-  facet normal -0.773011 -0.634393 0
+  facet normal 0.965926 -0.258819 0
     outer loop
-      vertex -16.1393 -16.5324 0
-      vertex -16.3165 -16.3165 10
-      vertex -16.3165 -16.3165 0
+      vertex -18.9139 -17.8556 10
+      vertex -18.4352 -16.0689 0
+      vertex -18.4352 -16.0689 10
     endloop
   endfacet
-  facet normal -0.773011 -0.634393 0
+  facet normal 0.965926 -0.258819 0
     outer loop
-      vertex -16.3165 -16.3165 10
-      vertex -16.1393 -16.5324 0
-      vertex -16.1393 -16.5324 10
-    endloop
-  endfacet
-  facet normal -0.995185 0.098017 0
-    outer loop
-      vertex -15.9265 -17.6021 0
-      vertex -15.8991 -17.3241 10
-      vertex -15.8991 -17.3241 0
-    endloop
-  endfacet
-  facet normal -0.995185 0.098017 0
-    outer loop
-      vertex -15.8991 -17.3241 10
-      vertex -15.9265 -17.6021 0
-      vertex -15.9265 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.0980137 0
-    outer loop
-      vertex -18.7491 -17.3241 10
-      vertex -18.7217 -17.0461 0
-      vertex -18.7217 -17.0461 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.0980137 0
-    outer loop
-      vertex -18.7217 -17.0461 0
-      vertex -18.7491 -17.3241 10
-      vertex -18.7491 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0.0980137 0.995185 -0
-    outer loop
-      vertex -17.3241 -18.7491 0
-      vertex -17.6021 -18.7217 10
-      vertex -17.3241 -18.7491 10
-    endloop
-  endfacet
-  facet normal 0.0980137 0.995185 0
-    outer loop
-      vertex -17.6021 -18.7217 10
-      vertex -17.3241 -18.7491 0
-      vertex -17.6021 -18.7217 0
-    endloop
-  endfacet
-  facet normal 0.098017 -0.995185 0
-    outer loop
-      vertex -17.6021 -15.9265 0
-      vertex -17.3241 -15.8991 10
-      vertex -17.6021 -15.9265 10
-    endloop
-  endfacet
-  facet normal 0.098017 -0.995185 0
-    outer loop
-      vertex -17.3241 -15.8991 10
-      vertex -17.6021 -15.9265 0
-      vertex -17.3241 -15.8991 0
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290285 0
-    outer loop
-      vertex -18.7217 -17.0461 10
-      vertex -18.6406 -16.7788 0
-      vertex -18.6406 -16.7788 10
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290285 0
-    outer loop
-      vertex -18.6406 -16.7788 0
-      vertex -18.7217 -17.0461 10
-      vertex -18.7217 -17.0461 0
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471396 0
-    outer loop
-      vertex -18.6406 -16.7788 10
-      vertex -18.509 -16.5324 0
-      vertex -18.509 -16.5324 10
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471396 0
-    outer loop
-      vertex -18.509 -16.5324 0
-      vertex -18.6406 -16.7788 10
-      vertex -18.6406 -16.7788 0
-    endloop
-  endfacet
-  facet normal 0.881923 0.471393 0
-    outer loop
-      vertex -18.509 -18.1158 10
-      vertex -18.6406 -17.8694 0
-      vertex -18.6406 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0.881923 0.471393 0
-    outer loop
-      vertex -18.6406 -17.8694 0
-      vertex -18.509 -18.1158 10
-      vertex -18.509 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0.995185 0.0980137 0
-    outer loop
-      vertex -18.7217 -17.6021 10
-      vertex -18.7491 -17.3241 0
-      vertex -18.7491 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0.995185 0.0980137 0
-    outer loop
-      vertex -18.7491 -17.3241 0
-      vertex -18.7217 -17.6021 10
-      vertex -18.7217 -17.6021 0
-    endloop
-  endfacet
-  facet normal -0.0980137 0.995185 0
-    outer loop
-      vertex -17.0461 -18.7217 0
-      vertex -17.3241 -18.7491 10
-      vertex -17.0461 -18.7217 10
-    endloop
-  endfacet
-  facet normal -0.0980137 0.995185 0
-    outer loop
-      vertex -17.3241 -18.7491 10
-      vertex -17.0461 -18.7217 0
-      vertex -17.3241 -18.7491 0
-    endloop
-  endfacet
-  facet normal -0.471396 0.881922 0
-    outer loop
-      vertex -16.5324 -18.509 0
-      vertex -16.7788 -18.6406 10
-      vertex -16.5324 -18.509 10
-    endloop
-  endfacet
-  facet normal -0.471396 0.881922 0
-    outer loop
-      vertex -16.7788 -18.6406 10
-      vertex -16.5324 -18.509 0
-      vertex -16.7788 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0.290287 0.95694 -0
-    outer loop
-      vertex -17.6021 -18.7217 0
-      vertex -17.8694 -18.6406 10
-      vertex -17.6021 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0.290287 0.95694 0
-    outer loop
-      vertex -17.8694 -18.6406 10
-      vertex -17.6021 -18.7217 0
-      vertex -17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 -0
-    outer loop
-      vertex -18.1158 -18.509 0
-      vertex -18.3317 -18.3317 10
-      vertex -18.1158 -18.509 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 0
-    outer loop
-      vertex -18.3317 -18.3317 10
-      vertex -18.1158 -18.509 0
-      vertex -18.3317 -18.3317 0
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex -18.3317 -16.3165 0
-      vertex -18.1158 -16.1393 10
-      vertex -18.3317 -16.3165 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex -18.1158 -16.1393 10
-      vertex -18.3317 -16.3165 0
-      vertex -18.1158 -16.1393 0
-    endloop
-  endfacet
-  facet normal -0.290285 -0.95694 0
-    outer loop
-      vertex -17.0461 -15.9265 0
-      vertex -16.7788 -16.0076 10
-      vertex -17.0461 -15.9265 10
-    endloop
-  endfacet
-  facet normal -0.290285 -0.95694 -0
-    outer loop
-      vertex -16.7788 -16.0076 10
-      vertex -17.0461 -15.9265 0
-      vertex -16.7788 -16.0076 0
-    endloop
-  endfacet
-  facet normal -0.098017 -0.995185 0
-    outer loop
-      vertex -17.3241 -15.8991 0
-      vertex -17.0461 -15.9265 10
-      vertex -17.3241 -15.8991 10
-    endloop
-  endfacet
-  facet normal -0.098017 -0.995185 -0
-    outer loop
-      vertex -17.0461 -15.9265 10
-      vertex -17.3241 -15.8991 0
-      vertex -17.0461 -15.9265 0
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290285 0
-    outer loop
-      vertex -15.9265 -17.0461 0
-      vertex -16.0076 -16.7788 10
-      vertex -16.0076 -16.7788 0
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290285 0
-    outer loop
-      vertex -16.0076 -16.7788 10
-      vertex -15.9265 -17.0461 0
-      vertex -15.9265 -17.0461 10
-    endloop
-  endfacet
-  facet normal -0.995185 -0.098017 0
-    outer loop
-      vertex -15.8991 -17.3241 0
-      vertex -15.9265 -17.0461 10
-      vertex -15.9265 -17.0461 0
-    endloop
-  endfacet
-  facet normal -0.995185 -0.098017 0
-    outer loop
-      vertex -15.9265 -17.0461 10
-      vertex -15.8991 -17.3241 0
-      vertex -15.8991 -17.3241 10
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471396 0
-    outer loop
-      vertex -16.0076 -16.7788 0
-      vertex -16.1393 -16.5324 10
-      vertex -16.1393 -16.5324 0
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471396 0
-    outer loop
-      vertex -16.1393 -16.5324 10
-      vertex -16.0076 -16.7788 0
-      vertex -16.0076 -16.7788 10
-    endloop
-  endfacet
-  facet normal -0.95694 0.290287 0
-    outer loop
-      vertex -16.0076 -17.8694 0
-      vertex -15.9265 -17.6021 10
-      vertex -15.9265 -17.6021 0
-    endloop
-  endfacet
-  facet normal -0.95694 0.290287 0
-    outer loop
-      vertex -15.9265 -17.6021 10
-      vertex -16.0076 -17.8694 0
-      vertex -16.0076 -17.8694 10
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex -16.3165 -18.3317 0
-      vertex -16.1393 -18.1158 10
-      vertex -16.1393 -18.1158 0
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex -16.1393 -18.1158 10
-      vertex -16.3165 -18.3317 0
-      vertex -16.3165 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex -18.3317 -18.3317 10
-      vertex -18.509 -18.1158 0
-      vertex -18.509 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex -18.509 -18.1158 0
-      vertex -18.3317 -18.3317 10
-      vertex -18.3317 -18.3317 0
-    endloop
-  endfacet
-  facet normal 0.95694 0.290287 0
-    outer loop
-      vertex -18.6406 -17.8694 10
-      vertex -18.7217 -17.6021 0
-      vertex -18.7217 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0.95694 0.290287 0
-    outer loop
-      vertex -18.7217 -17.6021 0
-      vertex -18.6406 -17.8694 10
-      vertex -18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal -0.290285 0.95694 0
-    outer loop
-      vertex -16.7788 -18.6406 0
-      vertex -17.0461 -18.7217 10
-      vertex -16.7788 -18.6406 10
-    endloop
-  endfacet
-  facet normal -0.290285 0.95694 0
-    outer loop
-      vertex -17.0461 -18.7217 10
-      vertex -16.7788 -18.6406 0
-      vertex -17.0461 -18.7217 0
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex -16.3165 -18.3317 0
-      vertex -16.5324 -18.509 10
-      vertex -16.3165 -18.3317 10
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex -16.5324 -18.509 10
-      vertex -16.3165 -18.3317 0
-      vertex -16.5324 -18.509 0
-    endloop
-  endfacet
-  facet normal 0.471393 0.881923 -0
-    outer loop
-      vertex -17.8694 -18.6406 0
-      vertex -18.1158 -18.509 10
-      vertex -17.8694 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0.471393 0.881923 0
-    outer loop
-      vertex -18.1158 -18.509 10
-      vertex -17.8694 -18.6406 0
-      vertex -18.1158 -18.509 0
-    endloop
-  endfacet
-  facet normal -0.471396 -0.881922 0
-    outer loop
-      vertex -16.7788 -16.0076 0
-      vertex -16.5324 -16.1393 10
-      vertex -16.7788 -16.0076 10
-    endloop
-  endfacet
-  facet normal -0.471396 -0.881922 -0
-    outer loop
-      vertex -16.5324 -16.1393 10
-      vertex -16.7788 -16.0076 0
-      vertex -16.5324 -16.1393 0
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 0
-    outer loop
-      vertex -16.5324 -16.1393 0
-      vertex -16.3165 -16.3165 10
-      vertex -16.5324 -16.1393 10
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 -0
-    outer loop
-      vertex -16.3165 -16.3165 10
-      vertex -16.5324 -16.1393 0
-      vertex -16.3165 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0.471393 -0.881923 0
-    outer loop
-      vertex -18.1158 -16.1393 0
-      vertex -17.8694 -16.0076 10
-      vertex -18.1158 -16.1393 10
-    endloop
-  endfacet
-  facet normal 0.471393 -0.881923 0
-    outer loop
-      vertex -17.8694 -16.0076 10
-      vertex -18.1158 -16.1393 0
-      vertex -17.8694 -16.0076 0
-    endloop
-  endfacet
-  facet normal 0.290287 -0.95694 0
-    outer loop
-      vertex -17.8694 -16.0076 0
-      vertex -17.6021 -15.9265 10
-      vertex -17.8694 -16.0076 10
-    endloop
-  endfacet
-  facet normal 0.290287 -0.95694 0
-    outer loop
-      vertex -17.6021 -15.9265 10
-      vertex -17.8694 -16.0076 0
-      vertex -17.6021 -15.9265 0
-    endloop
-  endfacet
-  facet normal -0.881923 0.471393 0
-    outer loop
-      vertex -16.1393 -18.1158 0
-      vertex -16.0076 -17.8694 10
-      vertex -16.0076 -17.8694 0
-    endloop
-  endfacet
-  facet normal -0.881923 0.471393 0
-    outer loop
-      vertex -16.0076 -17.8694 10
-      vertex -16.1393 -18.1158 0
-      vertex -16.1393 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 -0
-    outer loop
-      vertex 16.5324 -18.509 0
-      vertex 16.3165 -18.3317 10
-      vertex 16.5324 -18.509 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 0
-    outer loop
-      vertex 16.3165 -18.3317 10
-      vertex 16.5324 -18.509 0
-      vertex 16.3165 -18.3317 0
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex 18.509 -16.5324 0
-      vertex 18.3317 -16.3165 10
-      vertex 18.3317 -16.3165 0
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex 18.3317 -16.3165 10
-      vertex 18.509 -16.5324 0
-      vertex 18.509 -16.5324 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex 16.3165 -16.3165 0
-      vertex 16.5324 -16.1393 10
-      vertex 16.3165 -16.3165 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex 16.5324 -16.1393 10
-      vertex 16.3165 -16.3165 0
-      vertex 16.5324 -16.1393 0
-    endloop
-  endfacet
-  facet normal -0.098017 -0.995185 0
-    outer loop
-      vertex 17.3241 -15.8991 0
-      vertex 17.6021 -15.9265 10
-      vertex 17.3241 -15.8991 10
-    endloop
-  endfacet
-  facet normal -0.098017 -0.995185 -0
-    outer loop
-      vertex 17.6021 -15.9265 10
-      vertex 17.3241 -15.8991 0
-      vertex 17.6021 -15.9265 0
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980137 0
-    outer loop
-      vertex 18.7217 -17.6021 0
-      vertex 18.7491 -17.3241 10
-      vertex 18.7491 -17.3241 0
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980137 0
-    outer loop
-      vertex 18.7491 -17.3241 10
-      vertex 18.7217 -17.6021 0
-      vertex 18.7217 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0.995185 0.098017 0
-    outer loop
-      vertex 15.9265 -17.6021 10
-      vertex 15.8991 -17.3241 0
-      vertex 15.8991 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0.995185 0.098017 0
-    outer loop
-      vertex 15.8991 -17.3241 0
-      vertex 15.9265 -17.6021 10
-      vertex 15.9265 -17.6021 0
-    endloop
-  endfacet
-  facet normal -0.471393 -0.881923 0
-    outer loop
-      vertex 17.8694 -16.0076 0
-      vertex 18.1158 -16.1393 10
-      vertex 17.8694 -16.0076 10
-    endloop
-  endfacet
-  facet normal -0.471393 -0.881923 -0
-    outer loop
-      vertex 18.1158 -16.1393 10
-      vertex 17.8694 -16.0076 0
-      vertex 18.1158 -16.1393 0
-    endloop
-  endfacet
-  facet normal 0.471396 0.881922 -0
-    outer loop
-      vertex 16.7788 -18.6406 0
-      vertex 16.5324 -18.509 10
-      vertex 16.7788 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0.471396 0.881922 0
-    outer loop
-      vertex 16.5324 -18.509 10
-      vertex 16.7788 -18.6406 0
-      vertex 16.5324 -18.509 0
-    endloop
-  endfacet
-  facet normal 0.0980137 0.995185 -0
-    outer loop
-      vertex 17.3241 -18.7491 0
-      vertex 17.0461 -18.7217 10
-      vertex 17.3241 -18.7491 10
-    endloop
-  endfacet
-  facet normal 0.0980137 0.995185 0
-    outer loop
-      vertex 17.0461 -18.7217 10
-      vertex 17.3241 -18.7491 0
-      vertex 17.0461 -18.7217 0
-    endloop
-  endfacet
-  facet normal -0.471393 0.881923 0
-    outer loop
-      vertex 18.1158 -18.509 0
-      vertex 17.8694 -18.6406 10
-      vertex 18.1158 -18.509 10
-    endloop
-  endfacet
-  facet normal -0.471393 0.881923 0
-    outer loop
-      vertex 17.8694 -18.6406 10
-      vertex 18.1158 -18.509 0
-      vertex 17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal -0.0980137 0.995185 0
-    outer loop
-      vertex 17.6021 -18.7217 0
-      vertex 17.3241 -18.7491 10
-      vertex 17.6021 -18.7217 10
-    endloop
-  endfacet
-  facet normal -0.0980137 0.995185 0
-    outer loop
-      vertex 17.3241 -18.7491 10
-      vertex 17.6021 -18.7217 0
-      vertex 17.3241 -18.7491 0
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290285 0
-    outer loop
-      vertex 18.7217 -17.0461 0
-      vertex 18.6406 -16.7788 10
-      vertex 18.6406 -16.7788 0
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290285 0
-    outer loop
-      vertex 18.6406 -16.7788 10
-      vertex 18.7217 -17.0461 0
-      vertex 18.7217 -17.0461 10
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980137 0
-    outer loop
-      vertex 18.7491 -17.3241 0
-      vertex 18.7217 -17.0461 10
-      vertex 18.7217 -17.0461 0
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980137 0
-    outer loop
-      vertex 18.7217 -17.0461 10
-      vertex 18.7491 -17.3241 0
-      vertex 18.7491 -17.3241 10
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471396 0
-    outer loop
-      vertex 18.6406 -16.7788 0
-      vertex 18.509 -16.5324 10
-      vertex 18.509 -16.5324 0
-    endloop
-  endfacet
-  facet normal -0.881922 -0.471396 0
-    outer loop
-      vertex 18.509 -16.5324 10
-      vertex 18.6406 -16.7788 0
-      vertex 18.6406 -16.7788 10
-    endloop
-  endfacet
-  facet normal -0.95694 0.290287 0
-    outer loop
-      vertex 18.6406 -17.8694 0
-      vertex 18.7217 -17.6021 10
-      vertex 18.7217 -17.6021 0
-    endloop
-  endfacet
-  facet normal -0.95694 0.290287 0
-    outer loop
-      vertex 18.7217 -17.6021 10
-      vertex 18.6406 -17.8694 0
-      vertex 18.6406 -17.8694 10
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex 18.3317 -18.3317 0
-      vertex 18.509 -18.1158 10
-      vertex 18.509 -18.1158 0
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex 18.509 -18.1158 10
-      vertex 18.3317 -18.3317 0
-      vertex 18.3317 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 16.3165 -18.3317 10
-      vertex 16.1393 -18.1158 0
-      vertex 16.1393 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 16.1393 -18.1158 0
-      vertex 16.3165 -18.3317 10
-      vertex 16.3165 -18.3317 0
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290285 0
-    outer loop
-      vertex 15.9265 -17.0461 10
-      vertex 16.0076 -16.7788 0
-      vertex 16.0076 -16.7788 10
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290285 0
-    outer loop
-      vertex 16.0076 -16.7788 0
-      vertex 15.9265 -17.0461 10
-      vertex 15.9265 -17.0461 0
-    endloop
-  endfacet
-  facet normal 0.995185 -0.098017 0
-    outer loop
-      vertex 15.8991 -17.3241 10
-      vertex 15.9265 -17.0461 0
-      vertex 15.9265 -17.0461 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.098017 0
-    outer loop
-      vertex 15.9265 -17.0461 0
-      vertex 15.8991 -17.3241 10
-      vertex 15.8991 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0.290285 -0.95694 0
-    outer loop
-      vertex 16.7788 -16.0076 0
-      vertex 17.0461 -15.9265 10
-      vertex 16.7788 -16.0076 10
-    endloop
-  endfacet
-  facet normal 0.290285 -0.95694 0
-    outer loop
-      vertex 17.0461 -15.9265 10
-      vertex 16.7788 -16.0076 0
-      vertex 17.0461 -15.9265 0
-    endloop
-  endfacet
-  facet normal 0.098017 -0.995185 0
-    outer loop
-      vertex 17.0461 -15.9265 0
-      vertex 17.3241 -15.8991 10
-      vertex 17.0461 -15.9265 10
-    endloop
-  endfacet
-  facet normal 0.098017 -0.995185 0
-    outer loop
-      vertex 17.3241 -15.8991 10
-      vertex 17.0461 -15.9265 0
-      vertex 17.3241 -15.8991 0
-    endloop
-  endfacet
-  facet normal 0.471396 -0.881922 0
-    outer loop
-      vertex 16.5324 -16.1393 0
-      vertex 16.7788 -16.0076 10
-      vertex 16.5324 -16.1393 10
-    endloop
-  endfacet
-  facet normal 0.471396 -0.881922 0
-    outer loop
-      vertex 16.7788 -16.0076 10
-      vertex 16.5324 -16.1393 0
-      vertex 16.7788 -16.0076 0
-    endloop
-  endfacet
-  facet normal -0.290287 -0.95694 0
-    outer loop
-      vertex 17.6021 -15.9265 0
-      vertex 17.8694 -16.0076 10
-      vertex 17.6021 -15.9265 10
-    endloop
-  endfacet
-  facet normal -0.290287 -0.95694 -0
-    outer loop
-      vertex 17.8694 -16.0076 10
-      vertex 17.6021 -15.9265 0
-      vertex 17.8694 -16.0076 0
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 0
-    outer loop
-      vertex 18.1158 -16.1393 0
-      vertex 18.3317 -16.3165 10
-      vertex 18.1158 -16.1393 10
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 -0
-    outer loop
-      vertex 18.3317 -16.3165 10
-      vertex 18.1158 -16.1393 0
-      vertex 18.3317 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0.290285 0.95694 -0
-    outer loop
-      vertex 17.0461 -18.7217 0
-      vertex 16.7788 -18.6406 10
-      vertex 17.0461 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0.290285 0.95694 0
-    outer loop
-      vertex 16.7788 -18.6406 10
-      vertex 17.0461 -18.7217 0
-      vertex 16.7788 -18.6406 0
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 18.3317 -18.3317 0
-      vertex 18.1158 -18.509 10
-      vertex 18.3317 -18.3317 10
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 18.1158 -18.509 10
-      vertex 18.3317 -18.3317 0
-      vertex 18.1158 -18.509 0
-    endloop
-  endfacet
-  facet normal -0.290287 0.95694 0
-    outer loop
-      vertex 17.8694 -18.6406 0
-      vertex 17.6021 -18.7217 10
-      vertex 17.8694 -18.6406 10
-    endloop
-  endfacet
-  facet normal -0.290287 0.95694 0
-    outer loop
-      vertex 17.6021 -18.7217 10
-      vertex 17.8694 -18.6406 0
-      vertex 17.6021 -18.7217 0
-    endloop
-  endfacet
-  facet normal -0.881923 0.471393 0
-    outer loop
-      vertex 18.509 -18.1158 0
-      vertex 18.6406 -17.8694 10
-      vertex 18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal -0.881923 0.471393 0
-    outer loop
-      vertex 18.6406 -17.8694 10
-      vertex 18.509 -18.1158 0
-      vertex 18.509 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471396 0
-    outer loop
-      vertex 16.0076 -16.7788 10
-      vertex 16.1393 -16.5324 0
-      vertex 16.1393 -16.5324 10
-    endloop
-  endfacet
-  facet normal 0.881922 -0.471396 0
-    outer loop
-      vertex 16.1393 -16.5324 0
-      vertex 16.0076 -16.7788 10
-      vertex 16.0076 -16.7788 0
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 16.1393 -16.5324 10
-      vertex 16.3165 -16.3165 0
-      vertex 16.3165 -16.3165 10
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 16.3165 -16.3165 0
-      vertex 16.1393 -16.5324 10
-      vertex 16.1393 -16.5324 0
-    endloop
-  endfacet
-  facet normal 0.881923 0.471393 0
-    outer loop
-      vertex 16.1393 -18.1158 10
-      vertex 16.0076 -17.8694 0
-      vertex 16.0076 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0.881923 0.471393 0
-    outer loop
-      vertex 16.0076 -17.8694 0
-      vertex 16.1393 -18.1158 10
-      vertex 16.1393 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0.95694 0.290287 0
-    outer loop
-      vertex 16.0076 -17.8694 10
-      vertex 15.9265 -17.6021 0
-      vertex 15.9265 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0.95694 0.290287 0
-    outer loop
-      vertex 15.9265 -17.6021 0
-      vertex 16.0076 -17.8694 10
-      vertex 16.0076 -17.8694 0
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex 18.3317 16.3165 0
-      vertex 18.509 16.5324 10
-      vertex 18.509 16.5324 0
-    endloop
-  endfacet
-  facet normal -0.773011 0.634393 0
-    outer loop
-      vertex 18.509 16.5324 10
-      vertex 18.3317 16.3165 0
-      vertex 18.3317 16.3165 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex 16.3165 18.3317 0
-      vertex 16.5324 18.509 10
-      vertex 16.3165 18.3317 10
-    endloop
-  endfacet
-  facet normal 0.634393 -0.773011 0
-    outer loop
-      vertex 16.5324 18.509 10
-      vertex 16.3165 18.3317 0
-      vertex 16.5324 18.509 0
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex 18.509 18.1158 0
-      vertex 18.3317 18.3317 10
-      vertex 18.3317 18.3317 0
-    endloop
-  endfacet
-  facet normal -0.773011 -0.634393 0
-    outer loop
-      vertex 18.3317 18.3317 10
-      vertex 18.509 18.1158 0
-      vertex 18.509 18.1158 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.098017 0
-    outer loop
-      vertex 15.8991 17.3241 10
-      vertex 15.9265 17.6021 0
-      vertex 15.9265 17.6021 10
-    endloop
-  endfacet
-  facet normal 0.995185 -0.098017 0
-    outer loop
-      vertex 15.9265 17.6021 0
-      vertex 15.8991 17.3241 10
-      vertex 15.8991 17.3241 0
-    endloop
-  endfacet
-  facet normal -0.0980137 -0.995185 0
-    outer loop
-      vertex 17.3241 18.7491 0
-      vertex 17.6021 18.7217 10
-      vertex 17.3241 18.7491 10
-    endloop
-  endfacet
-  facet normal -0.0980137 -0.995185 -0
-    outer loop
-      vertex 17.6021 18.7217 10
-      vertex 17.3241 18.7491 0
-      vertex 17.6021 18.7217 0
-    endloop
-  endfacet
-  facet normal -0.471393 -0.881923 0
-    outer loop
-      vertex 17.8694 18.6406 0
-      vertex 18.1158 18.509 10
-      vertex 17.8694 18.6406 10
-    endloop
-  endfacet
-  facet normal -0.471393 -0.881923 -0
-    outer loop
-      vertex 18.1158 18.509 10
-      vertex 17.8694 18.6406 0
-      vertex 18.1158 18.509 0
-    endloop
-  endfacet
-  facet normal -0.098017 0.995185 0
-    outer loop
-      vertex 17.6021 15.9265 0
-      vertex 17.3241 15.8991 10
-      vertex 17.6021 15.9265 10
-    endloop
-  endfacet
-  facet normal -0.098017 0.995185 0
-    outer loop
-      vertex 17.3241 15.8991 10
-      vertex 17.6021 15.9265 0
-      vertex 17.3241 15.8991 0
-    endloop
-  endfacet
-  facet normal 0.881923 -0.471393 0
-    outer loop
-      vertex 16.0076 17.8694 10
-      vertex 16.1393 18.1158 0
-      vertex 16.1393 18.1158 10
-    endloop
-  endfacet
-  facet normal 0.881923 -0.471393 0
-    outer loop
-      vertex 16.1393 18.1158 0
-      vertex 16.0076 17.8694 10
-      vertex 16.0076 17.8694 0
-    endloop
-  endfacet
-  facet normal -0.881922 0.471396 0
-    outer loop
-      vertex 18.509 16.5324 0
-      vertex 18.6406 16.7788 10
-      vertex 18.6406 16.7788 0
-    endloop
-  endfacet
-  facet normal -0.881922 0.471396 0
-    outer loop
-      vertex 18.6406 16.7788 10
-      vertex 18.509 16.5324 0
-      vertex 18.509 16.5324 10
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980137 0
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 18.7491 17.3241 10
-      vertex 18.7491 17.3241 0
-    endloop
-  endfacet
-  facet normal -0.995185 0.0980137 0
-    outer loop
-      vertex 18.7491 17.3241 10
-      vertex 18.7217 17.0461 0
-      vertex 18.7217 17.0461 10
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290287 0
-    outer loop
-      vertex 18.7217 17.6021 0
-      vertex 18.6406 17.8694 10
-      vertex 18.6406 17.8694 0
-    endloop
-  endfacet
-  facet normal -0.95694 -0.290287 0
-    outer loop
-      vertex 18.6406 17.8694 10
-      vertex 18.7217 17.6021 0
-      vertex 18.7217 17.6021 10
-    endloop
-  endfacet
-  facet normal -0.881923 -0.471393 0
-    outer loop
-      vertex 18.6406 17.8694 0
-      vertex 18.509 18.1158 10
-      vertex 18.509 18.1158 0
-    endloop
-  endfacet
-  facet normal -0.881923 -0.471393 0
-    outer loop
-      vertex 18.509 18.1158 10
-      vertex 18.6406 17.8694 0
-      vertex 18.6406 17.8694 10
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980137 0
-    outer loop
-      vertex 18.7491 17.3241 0
-      vertex 18.7217 17.6021 10
-      vertex 18.7217 17.6021 0
-    endloop
-  endfacet
-  facet normal -0.995185 -0.0980137 0
-    outer loop
-      vertex 18.7217 17.6021 10
-      vertex 18.7491 17.3241 0
-      vertex 18.7491 17.3241 10
-    endloop
-  endfacet
-  facet normal 0.290285 -0.95694 0
-    outer loop
-      vertex 16.7788 18.6406 0
-      vertex 17.0461 18.7217 10
-      vertex 16.7788 18.6406 10
-    endloop
-  endfacet
-  facet normal 0.290285 -0.95694 0
-    outer loop
-      vertex 17.0461 18.7217 10
-      vertex 16.7788 18.6406 0
-      vertex 17.0461 18.7217 0
-    endloop
-  endfacet
-  facet normal 0.0980137 -0.995185 0
-    outer loop
-      vertex 17.0461 18.7217 0
-      vertex 17.3241 18.7491 10
-      vertex 17.0461 18.7217 10
-    endloop
-  endfacet
-  facet normal 0.0980137 -0.995185 0
-    outer loop
-      vertex 17.3241 18.7491 10
-      vertex 17.0461 18.7217 0
-      vertex 17.3241 18.7491 0
-    endloop
-  endfacet
-  facet normal 0.471396 -0.881922 0
-    outer loop
-      vertex 16.5324 18.509 0
-      vertex 16.7788 18.6406 10
-      vertex 16.5324 18.509 10
-    endloop
-  endfacet
-  facet normal 0.471396 -0.881922 0
-    outer loop
-      vertex 16.7788 18.6406 10
-      vertex 16.5324 18.509 0
-      vertex 16.7788 18.6406 0
-    endloop
-  endfacet
-  facet normal -0.290287 -0.95694 0
-    outer loop
-      vertex 17.6021 18.7217 0
-      vertex 17.8694 18.6406 10
-      vertex 17.6021 18.7217 10
-    endloop
-  endfacet
-  facet normal -0.290287 -0.95694 -0
-    outer loop
-      vertex 17.8694 18.6406 10
-      vertex 17.6021 18.7217 0
-      vertex 17.8694 18.6406 0
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 0
-    outer loop
-      vertex 18.1158 18.509 0
-      vertex 18.3317 18.3317 10
-      vertex 18.1158 18.509 10
-    endloop
-  endfacet
-  facet normal -0.634393 -0.773011 -0
-    outer loop
-      vertex 18.3317 18.3317 10
-      vertex 18.1158 18.509 0
-      vertex 18.3317 18.3317 0
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 18.3317 16.3165 0
-      vertex 18.1158 16.1393 10
-      vertex 18.3317 16.3165 10
-    endloop
-  endfacet
-  facet normal -0.634393 0.773011 0
-    outer loop
-      vertex 18.1158 16.1393 10
-      vertex 18.3317 16.3165 0
-      vertex 18.1158 16.1393 0
-    endloop
-  endfacet
-  facet normal 0.098017 0.995185 -0
-    outer loop
-      vertex 17.3241 15.8991 0
-      vertex 17.0461 15.9265 10
-      vertex 17.3241 15.8991 10
-    endloop
-  endfacet
-  facet normal 0.098017 0.995185 0
-    outer loop
-      vertex 17.0461 15.9265 10
-      vertex 17.3241 15.8991 0
-      vertex 17.0461 15.9265 0
-    endloop
-  endfacet
-  facet normal 0.995185 0.098017 0
-    outer loop
-      vertex 15.9265 17.0461 10
-      vertex 15.8991 17.3241 0
-      vertex 15.8991 17.3241 10
-    endloop
-  endfacet
-  facet normal 0.995185 0.098017 0
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 15.9265 17.0461 10
-      vertex 15.9265 17.0461 0
-    endloop
-  endfacet
-  facet normal 0.881922 0.471396 0
-    outer loop
-      vertex 16.1393 16.5324 10
-      vertex 16.0076 16.7788 0
-      vertex 16.0076 16.7788 10
-    endloop
-  endfacet
-  facet normal 0.881922 0.471396 0
-    outer loop
-      vertex 16.0076 16.7788 0
-      vertex 16.1393 16.5324 10
-      vertex 16.1393 16.5324 0
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290287 0
-    outer loop
-      vertex 15.9265 17.6021 10
-      vertex 16.0076 17.8694 0
-      vertex 16.0076 17.8694 10
-    endloop
-  endfacet
-  facet normal 0.95694 -0.290287 0
-    outer loop
-      vertex 16.0076 17.8694 0
-      vertex 15.9265 17.6021 10
-      vertex 15.9265 17.6021 0
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 16.1393 18.1158 10
-      vertex 16.3165 18.3317 0
-      vertex 16.3165 18.3317 10
-    endloop
-  endfacet
-  facet normal 0.773011 -0.634393 0
-    outer loop
-      vertex 16.3165 18.3317 0
-      vertex 16.1393 18.1158 10
-      vertex 16.1393 18.1158 0
-    endloop
-  endfacet
-  facet normal -0.95694 0.290285 0
-    outer loop
-      vertex 18.6406 16.7788 0
-      vertex 18.7217 17.0461 10
-      vertex 18.7217 17.0461 0
-    endloop
-  endfacet
-  facet normal -0.95694 0.290285 0
-    outer loop
-      vertex 18.7217 17.0461 10
-      vertex 18.6406 16.7788 0
-      vertex 18.6406 16.7788 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 -0
-    outer loop
-      vertex 16.5324 16.1393 0
-      vertex 16.3165 16.3165 10
-      vertex 16.5324 16.1393 10
-    endloop
-  endfacet
-  facet normal 0.634393 0.773011 0
-    outer loop
-      vertex 16.3165 16.3165 10
-      vertex 16.5324 16.1393 0
-      vertex 16.3165 16.3165 0
-    endloop
-  endfacet
-  facet normal 0.290285 0.95694 -0
-    outer loop
-      vertex 17.0461 15.9265 0
-      vertex 16.7788 16.0076 10
-      vertex 17.0461 15.9265 10
-    endloop
-  endfacet
-  facet normal 0.290285 0.95694 0
-    outer loop
-      vertex 16.7788 16.0076 10
-      vertex 17.0461 15.9265 0
-      vertex 16.7788 16.0076 0
-    endloop
-  endfacet
-  facet normal -0.471393 0.881923 0
-    outer loop
-      vertex 18.1158 16.1393 0
-      vertex 17.8694 16.0076 10
-      vertex 18.1158 16.1393 10
-    endloop
-  endfacet
-  facet normal -0.471393 0.881923 0
-    outer loop
-      vertex 17.8694 16.0076 10
-      vertex 18.1158 16.1393 0
-      vertex 17.8694 16.0076 0
-    endloop
-  endfacet
-  facet normal -0.290287 0.95694 0
-    outer loop
-      vertex 17.8694 16.0076 0
-      vertex 17.6021 15.9265 10
-      vertex 17.8694 16.0076 10
-    endloop
-  endfacet
-  facet normal -0.290287 0.95694 0
-    outer loop
-      vertex 17.6021 15.9265 10
-      vertex 17.8694 16.0076 0
-      vertex 17.6021 15.9265 0
-    endloop
-  endfacet
-  facet normal 0.95694 0.290285 0
-    outer loop
-      vertex 16.0076 16.7788 10
-      vertex 15.9265 17.0461 0
-      vertex 15.9265 17.0461 10
-    endloop
-  endfacet
-  facet normal 0.95694 0.290285 0
-    outer loop
-      vertex 15.9265 17.0461 0
-      vertex 16.0076 16.7788 10
-      vertex 16.0076 16.7788 0
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 16.3165 16.3165 10
-      vertex 16.1393 16.5324 0
-      vertex 16.1393 16.5324 10
-    endloop
-  endfacet
-  facet normal 0.773011 0.634393 0
-    outer loop
-      vertex 16.1393 16.5324 0
-      vertex 16.3165 16.3165 10
-      vertex 16.3165 16.3165 0
-    endloop
-  endfacet
-  facet normal 0.471396 0.881922 -0
-    outer loop
-      vertex 16.7788 16.0076 0
-      vertex 16.5324 16.1393 10
-      vertex 16.7788 16.0076 10
-    endloop
-  endfacet
-  facet normal 0.471396 0.881922 0
-    outer loop
-      vertex 16.5324 16.1393 10
-      vertex 16.7788 16.0076 0
-      vertex 16.5324 16.1393 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex 14.8492 -25.4558 10
-      vertex -14.8492 -25.4558 10
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 14.8492 -25.4558 10
-      vertex -14.8492 -25.4558 0
-      vertex 14.8492 -25.4558 0
+      vertex -18.4352 -16.0689 0
+      vertex -18.9139 -17.8556 10
+      vertex -18.9139 -17.8556 0
     endloop
   endfacet
   facet normal -0.707107 -0.707107 0
     outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -25.4558 -14.8492 10
-      vertex -25.4558 -14.8492 0
+      vertex -15.6815 -16.9895 0
+      vertex -16.9895 -15.6815 10
+      vertex -16.9895 -15.6815 0
     endloop
   endfacet
   facet normal -0.707107 -0.707107 0
     outer loop
-      vertex -25.4558 -14.8492 10
-      vertex -14.8492 -25.4558 0
-      vertex -14.8492 -25.4558 10
+      vertex -16.9895 -15.6815 10
+      vertex -15.6815 -16.9895 0
+      vertex -15.6815 -16.9895 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.162896 -0.986643 0
     outer loop
-      vertex -14.1421 14.1421 10
-      vertex -18.0359 13.7838 10
-      vertex -17.9668 13.0815 10
+      vertex -17.8159 -15.4889 0
+      vertex -17.6418 -15.4601 10
+      vertex -17.8159 -15.4889 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.162896 -0.986643 0
     outer loop
-      vertex -18.5735 15.0815 10
-      vertex -17.8694 16.0076 10
-      vertex -18.1158 16.1393 10
+      vertex -17.6418 -15.4601 10
+      vertex -17.8159 -15.4889 0
+      vertex -17.6418 -15.4601 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995185 -0.0980094 0
     outer loop
-      vertex -17.6021 15.9265 10
-      vertex -18.2408 14.4591 10
-      vertex -18.0359 13.7838 10
+      vertex -18.9312 -18.0312 10
+      vertex -18.9139 -17.8556 0
+      vertex -18.9139 -17.8556 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995185 -0.0980094 0
     outer loop
-      vertex -19.0212 15.6271 10
-      vertex -18.1158 16.1393 10
-      vertex -18.3317 16.3165 10
+      vertex -18.9139 -17.8556 0
+      vertex -18.9312 -18.0312 10
+      vertex -18.9312 -18.0312 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.812844 -0.582482 0
     outer loop
-      vertex -19.0212 15.6271 10
-      vertex -18.3317 16.3165 10
-      vertex -18.509 16.5324 10
+      vertex -15.5788 -17.1329 0
+      vertex -15.6815 -16.9895 10
+      vertex -15.6815 -16.9895 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.812844 -0.582482 0
     outer loop
-      vertex -17.6021 15.9265 10
-      vertex -18.5735 15.0815 10
-      vertex -18.2408 14.4591 10
+      vertex -15.6815 -16.9895 10
+      vertex -15.5788 -17.1329 0
+      vertex -15.5788 -17.1329 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.412708 -0.910863 0
     outer loop
-      vertex -19.5667 16.0748 10
-      vertex -18.509 16.5324 10
-      vertex -18.6406 16.7788 10
+      vertex -17.2936 -15.506 0
+      vertex -17.1329 -15.5788 10
+      vertex -17.2936 -15.506 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.412708 -0.910863 -0
     outer loop
-      vertex -19.5667 16.0748 10
-      vertex -18.6406 16.7788 10
-      vertex -18.7217 17.0461 10
+      vertex -17.1329 -15.5788 10
+      vertex -17.2936 -15.506 0
+      vertex -17.1329 -15.5788 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0980094 0.995185 0
     outer loop
-      vertex -20.1891 16.4074 10
-      vertex -18.7217 17.0461 10
-      vertex -18.7491 17.3241 10
+      vertex -17.8556 -18.9139 0
+      vertex -18.0312 -18.9312 10
+      vertex -17.8556 -18.9139 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0980094 0.995185 0
     outer loop
-      vertex -18.1158 16.1393 10
-      vertex -19.0212 15.6271 10
-      vertex -18.5735 15.0815 10
+      vertex -18.0312 -18.9312 10
+      vertex -17.8556 -18.9139 0
+      vertex -18.0312 -18.9312 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.258819 0.965926 0
     outer loop
-      vertex -17.3241 -15.8991 10
-      vertex -18.2408 -14.4591 10
-      vertex -17.6021 -15.9265 10
+      vertex -16.0689 -18.4352 0
+      vertex -17.8556 -18.9139 10
+      vertex -16.0689 -18.4352 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.258819 0.965926 0
     outer loop
-      vertex -18.5735 -15.0815 10
-      vertex -17.6021 -15.9265 10
-      vertex -18.2408 -14.4591 10
+      vertex -17.8556 -18.9139 10
+      vertex -16.0689 -18.4352 0
+      vertex -17.8556 -18.9139 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.910863 -0.412708 0
     outer loop
-      vertex -17.6021 -15.9265 10
-      vertex -18.5735 -15.0815 10
-      vertex -17.8694 -16.0076 10
+      vertex -15.506 -17.2936 0
+      vertex -15.5788 -17.1329 10
+      vertex -15.5788 -17.1329 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.910863 -0.412708 0
     outer loop
-      vertex -17.8694 -16.0076 10
-      vertex -18.5735 -15.0815 10
-      vertex -18.1158 -16.1393 10
+      vertex -15.5788 -17.1329 10
+      vertex -15.506 -17.2936 0
+      vertex -15.506 -17.2936 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.227075 -0.973877 0
     outer loop
-      vertex -19.0212 -15.6271 10
-      vertex -18.1158 -16.1393 10
-      vertex -18.5735 -15.0815 10
+      vertex -17.4655 -15.4659 0
+      vertex -17.2936 -15.506 10
+      vertex -17.4655 -15.4659 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.227075 -0.973877 -0
     outer loop
-      vertex -18.1158 -16.1393 10
-      vertex -19.0212 -15.6271 10
-      vertex -18.3317 -16.3165 10
+      vertex -17.2936 -15.506 10
+      vertex -17.4655 -15.4659 0
+      vertex -17.2936 -15.506 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.582482 -0.812844 0
     outer loop
-      vertex -18.3317 -16.3165 10
-      vertex -19.0212 -15.6271 10
-      vertex -18.509 -16.5324 10
+      vertex -17.1329 -15.5788 0
+      vertex -16.9895 -15.6815 10
+      vertex -17.1329 -15.5788 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.582482 -0.812844 -0
     outer loop
-      vertex -19.5667 -16.0748 10
-      vertex -18.509 -16.5324 10
-      vertex -19.0212 -15.6271 10
+      vertex -16.9895 -15.6815 10
+      vertex -17.1329 -15.5788 0
+      vertex -16.9895 -15.6815 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0327187 -0.999465 0
     outer loop
-      vertex -18.509 -16.5324 10
-      vertex -19.5667 -16.0748 10
-      vertex -18.6406 -16.7788 10
+      vertex -17.6418 -15.4601 0
+      vertex -17.4655 -15.4659 10
+      vertex -17.6418 -15.4601 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0327187 -0.999465 -0
     outer loop
-      vertex -18.6406 -16.7788 10
-      vertex -19.5667 -16.0748 10
-      vertex -18.7217 -17.0461 10
+      vertex -17.4655 -15.4659 10
+      vertex -17.6418 -15.4601 0
+      vertex -17.4655 -15.4659 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.352251 -0.935906 0
     outer loop
-      vertex -14.4591 18.2408 10
-      vertex -15.9265 17.6021 10
-      vertex -15.8991 17.3241 10
+      vertex -17.981 -15.551 0
+      vertex -17.8159 -15.4889 10
+      vertex -17.981 -15.551 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.352251 -0.935906 0
     outer loop
-      vertex -15.0815 18.5735 10
-      vertex -16.0076 17.8694 10
-      vertex -15.9265 17.6021 10
+      vertex -17.8159 -15.4889 10
+      vertex -17.981 -15.551 0
+      vertex -17.8159 -15.4889 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.683596 -0.729861 0
     outer loop
-      vertex -16.5324 18.509 10
-      vertex -15.6271 19.0212 10
-      vertex -16.0748 19.5667 10
+      vertex -18.2596 -15.7648 0
+      vertex -18.1308 -15.6442 10
+      vertex -18.2596 -15.7648 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.683596 -0.729861 0
     outer loop
-      vertex -15.0815 18.5735 10
-      vertex -16.1393 18.1158 10
-      vertex -16.0076 17.8694 10
+      vertex -18.1308 -15.6442 10
+      vertex -18.2596 -15.7648 0
+      vertex -18.1308 -15.6442 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.528066 -0.849204 0
     outer loop
-      vertex -15.6271 19.0212 10
-      vertex -16.3165 18.3317 10
-      vertex -16.1393 18.1158 10
+      vertex -18.1308 -15.6442 0
+      vertex -17.981 -15.551 10
+      vertex -18.1308 -15.6442 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.528066 -0.849204 0
     outer loop
-      vertex -17.0461 18.7217 10
-      vertex -16.0748 19.5667 10
-      vertex -16.4074 20.1891 10
+      vertex -17.981 -15.551 10
+      vertex -18.1308 -15.6442 0
+      vertex -17.981 -15.551 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.812845 -0.58248 0
     outer loop
-      vertex -15.6271 19.0212 10
-      vertex -16.5324 18.509 10
-      vertex -16.3165 18.3317 10
+      vertex -18.3624 -15.9082 10
+      vertex -18.2596 -15.7648 0
+      vertex -18.2596 -15.7648 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.812845 -0.58248 0
     outer loop
-      vertex -17.6021 18.7217 10
-      vertex -16.4074 20.1891 10
-      vertex -16.6123 20.8644 10
+      vertex -18.2596 -15.7648 0
+      vertex -18.3624 -15.9082 10
+      vertex -18.3624 -15.9082 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.729861 0.683596 0
     outer loop
-      vertex -18.1158 18.509 10
-      vertex -16.6123 20.8644 10
-      vertex -16.6815 21.5668 10
+      vertex -15.7648 -18.2596 0
+      vertex -15.6442 -18.1308 10
+      vertex -15.6442 -18.1308 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.729861 0.683596 0
     outer loop
-      vertex -16.0748 19.5667 10
-      vertex -16.7788 18.6406 10
-      vertex -16.5324 18.509 10
+      vertex -15.6442 -18.1308 10
+      vertex -15.7648 -18.2596 0
+      vertex -15.7648 -18.2596 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.910865 -0.412705 0
     outer loop
-      vertex -5.17638 -19.3185 10
-      vertex -9.55065 -20.8644 10
-      vertex -9.48148 -21.5668 10
+      vertex -18.4352 -16.0689 10
+      vertex -18.3624 -15.9082 0
+      vertex -18.3624 -15.9082 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.910865 -0.412705 0
     outer loop
-      vertex -5.17638 -19.3185 10
-      vertex -9.75551 -20.1891 10
-      vertex -9.55065 -20.8644 10
+      vertex -18.3624 -15.9082 0
+      vertex -18.4352 -16.0689 10
+      vertex -18.4352 -16.0689 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956938 0.290291 0
     outer loop
-      vertex -10.0882 -19.5667 10
-      vertex -5.17638 -19.3185 10
-      vertex -10 -17.3205 10
+      vertex -18.8627 -18.3756 10
+      vertex -18.9139 -18.2068 0
+      vertex -18.9139 -18.2068 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956938 0.290291 0
     outer loop
-      vertex -5.17638 -19.3185 10
-      vertex -10.0882 -19.5667 10
-      vertex -9.75551 -20.1891 10
+      vertex -18.9139 -18.2068 0
+      vertex -18.8627 -18.3756 10
+      vertex -18.8627 -18.3756 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.881923 0.471394 0
     outer loop
-      vertex -10 -17.3205 10
-      vertex -10.5359 -19.0212 10
-      vertex -10.0882 -19.5667 10
+      vertex -18.7795 -18.5312 10
+      vertex -18.8627 -18.3756 0
+      vertex -18.8627 -18.3756 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.881923 0.471394 0
     outer loop
-      vertex -10 -17.3205 10
-      vertex -11.0814 -18.5735 10
-      vertex -10.5359 -19.0212 10
+      vertex -18.8627 -18.3756 0
+      vertex -18.7795 -18.5312 10
+      vertex -18.7795 -18.5312 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.773009 0.634394 0
     outer loop
-      vertex -10 -17.3205 10
-      vertex -11.7038 -18.2408 10
-      vertex -11.0814 -18.5735 10
+      vertex -18.6676 -18.6676 10
+      vertex -18.7795 -18.5312 0
+      vertex -18.7795 -18.5312 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.773009 0.634394 0
     outer loop
-      vertex -10 -17.3205 10
-      vertex -12.3792 -18.0359 10
-      vertex -11.7038 -18.2408 10
+      vertex -18.7795 -18.5312 0
+      vertex -18.6676 -18.6676 10
+      vertex -18.6676 -18.6676 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634394 0.773009 -0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -12.3792 -18.0359 10
-      vertex -10 -17.3205 10
+      vertex -18.5312 -18.7795 0
+      vertex -18.6676 -18.6676 10
+      vertex -18.5312 -18.7795 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634394 0.773009 0
     outer loop
-      vertex -12.3792 -18.0359 10
-      vertex -14.1421 -14.1421 10
-      vertex -13.0815 -17.9668 10
+      vertex -18.6676 -18.6676 10
+      vertex -18.5312 -18.7795 0
+      vertex -18.6676 -18.6676 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.471394 0.881923 -0
     outer loop
-      vertex -13.0815 -17.9668 10
-      vertex -14.1421 -14.1421 10
-      vertex -13.7838 -18.0359 10
+      vertex -18.3756 -18.8627 0
+      vertex -18.5312 -18.7795 10
+      vertex -18.3756 -18.8627 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.471394 0.881923 0
     outer loop
-      vertex -16.0076 -16.7788 10
-      vertex -13.7838 -18.0359 10
-      vertex -14.1421 -14.1421 10
+      vertex -18.5312 -18.7795 10
+      vertex -18.3756 -18.8627 0
+      vertex -18.5312 -18.7795 0
     endloop
   endfacet
-  facet normal -0 -0 1
+  facet normal -0.986643 0.162896 0
     outer loop
-      vertex -15.9265 -17.0461 10
-      vertex -13.7838 -18.0359 10
-      vertex -16.0076 -16.7788 10
+      vertex -15.4889 -17.8159 0
+      vertex -15.4601 -17.6418 10
+      vertex -15.4601 -17.6418 0
     endloop
   endfacet
-  facet normal -0 -0 1
+  facet normal -0.986643 0.162896 0
     outer loop
-      vertex -15.8991 -17.3241 10
-      vertex -14.4591 -18.2408 10
-      vertex -15.9265 -17.0461 10
+      vertex -15.4601 -17.6418 10
+      vertex -15.4889 -17.8159 0
+      vertex -15.4889 -17.8159 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.849204 0.528066 0
     outer loop
-      vertex -14.4591 -18.2408 10
-      vertex -15.9265 -17.6021 10
-      vertex -15.0815 -18.5735 10
+      vertex -15.6442 -18.1308 0
+      vertex -15.551 -17.981 10
+      vertex -15.551 -17.981 0
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.849204 0.528066 0
     outer loop
-      vertex -15.9265 -17.6021 10
-      vertex -14.4591 -18.2408 10
-      vertex -15.8991 -17.3241 10
+      vertex -15.551 -17.981 10
+      vertex -15.6442 -18.1308 0
+      vertex -15.6442 -18.1308 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.973877 -0.227075 0
     outer loop
-      vertex -13.7838 -18.0359 10
-      vertex -15.9265 -17.0461 10
-      vertex -14.4591 -18.2408 10
+      vertex -15.4659 -17.4655 0
+      vertex -15.506 -17.2936 10
+      vertex -15.506 -17.2936 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.973877 -0.227075 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -16.1393 -16.5324 10
-      vertex -16.0076 -16.7788 10
+      vertex -15.506 -17.2936 10
+      vertex -15.4659 -17.4655 0
+      vertex -15.4659 -17.4655 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.999465 -0.0327187 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -16.3165 -16.3165 10
-      vertex -16.1393 -16.5324 10
+      vertex -15.4601 -17.6418 0
+      vertex -15.4659 -17.4655 10
+      vertex -15.4659 -17.4655 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.999465 -0.0327187 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -16.5324 -16.1393 10
-      vertex -16.3165 -16.3165 10
+      vertex -15.4659 -17.4655 10
+      vertex -15.4601 -17.6418 0
+      vertex -15.4601 -17.6418 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995185 0.0980104 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -16.7788 -16.0076 10
-      vertex -16.5324 -16.1393 10
+      vertex -18.9139 -18.2068 10
+      vertex -18.9312 -18.0312 0
+      vertex -18.9312 -18.0312 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.995185 0.0980104 0
     outer loop
-      vertex -18.0359 -13.7838 10
-      vertex -14.1421 -14.1421 10
-      vertex -17.9668 -13.0815 10
+      vertex -18.9312 -18.0312 0
+      vertex -18.9139 -18.2068 10
+      vertex -18.9139 -18.2068 0
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.412705 0.910865 0
     outer loop
-      vertex -18.0359 -12.3792 10
-      vertex -14.1421 -14.1421 10
-      vertex -17.3205 -10 10
+      vertex -15.9082 -18.3624 0
+      vertex -16.0689 -18.4352 10
+      vertex -15.9082 -18.3624 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.412705 0.910865 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -18.0359 -13.7838 10
-      vertex -16.7788 -16.0076 10
+      vertex -16.0689 -18.4352 10
+      vertex -15.9082 -18.3624 0
+      vertex -16.0689 -18.4352 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290291 0.956938 -0
     outer loop
-      vertex -16.7788 -16.0076 10
-      vertex -18.0359 -13.7838 10
-      vertex -17.0461 -15.9265 10
+      vertex -18.2068 -18.9139 0
+      vertex -18.3756 -18.8627 10
+      vertex -18.2068 -18.9139 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.290291 0.956938 0
     outer loop
-      vertex -18.2408 -14.4591 10
-      vertex -17.0461 -15.9265 10
-      vertex -18.0359 -13.7838 10
+      vertex -18.3756 -18.8627 10
+      vertex -18.2068 -18.9139 0
+      vertex -18.3756 -18.8627 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.935906 0.352251 0
     outer loop
-      vertex -17.0461 -15.9265 10
-      vertex -18.2408 -14.4591 10
-      vertex -17.3241 -15.8991 10
+      vertex -15.551 -17.981 0
+      vertex -15.4889 -17.8159 10
+      vertex -15.4889 -17.8159 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.935906 0.352251 0
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -18.0359 -12.3792 10
-      vertex -17.9668 -13.0815 10
+      vertex -15.4889 -17.8159 10
+      vertex -15.551 -17.981 0
+      vertex -15.551 -17.981 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.58248 0.812845 0
     outer loop
-      vertex -17.3205 -10 10
-      vertex -18.2408 -11.7038 10
-      vertex -18.0359 -12.3792 10
+      vertex -15.7648 -18.2596 0
+      vertex -15.9082 -18.3624 10
+      vertex -15.7648 -18.2596 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.58248 0.812845 0
     outer loop
-      vertex -17.3205 -10 10
-      vertex -18.5735 -11.0814 10
-      vertex -18.2408 -11.7038 10
+      vertex -15.9082 -18.3624 10
+      vertex -15.7648 -18.2596 0
+      vertex -15.9082 -18.3624 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0980104 0.995185 -0
     outer loop
-      vertex -17.3205 -10 10
-      vertex -19.0212 -10.5359 10
-      vertex -18.5735 -11.0814 10
+      vertex -18.0312 -18.9312 0
+      vertex -18.2068 -18.9139 10
+      vertex -18.0312 -18.9312 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0980104 0.995185 0
     outer loop
-      vertex -19.5667 -10.0882 10
-      vertex -17.3205 -10 10
-      vertex -19.3185 -5.17638 10
+      vertex -18.2068 -18.9139 10
+      vertex -18.0312 -18.9312 0
+      vertex -18.2068 -18.9139 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.58248 0.812845 -0
     outer loop
-      vertex -17.3205 -10 10
-      vertex -19.5667 -10.0882 10
-      vertex -19.0212 -10.5359 10
+      vertex 15.9082 -18.3624 0
+      vertex 15.7648 -18.2596 10
+      vertex 15.9082 -18.3624 10
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.58248 0.812845 0
     outer loop
-      vertex -22.9444 -9.75551 10
-      vertex -19.3185 -5.17638 10
-      vertex -20 0 10
+      vertex 15.7648 -18.2596 10
+      vertex 15.9082 -18.3624 0
+      vertex 15.7648 -18.2596 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.683596 -0.729861 0
     outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -20.1891 -9.75551 10
-      vertex -19.5667 -10.0882 10
+      vertex 18.1308 -15.6442 0
+      vertex 18.2596 -15.7648 10
+      vertex 18.1308 -15.6442 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.683596 -0.729861 -0
     outer loop
-      vertex -21.5668 9.48148 10
-      vertex -19.3185 5.17638 10
-      vertex -20.8644 9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 9.55065 10
-      vertex -19.3185 5.17638 10
-      vertex -21.5668 9.48148 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -20.8644 -9.55065 10
-      vertex -20.1891 -9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.9444 9.75551 10
-      vertex -19.3185 5.17638 10
-      vertex -22.2691 9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -21.5668 -9.48148 10
-      vertex -20.8644 -9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3185 5.17638 10
-      vertex -22.9444 9.75551 10
-      vertex -20 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -22.2691 -9.55065 10
-      vertex -21.5668 -9.48148 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 10.0882 10
-      vertex -20 0 10
-      vertex -22.9444 9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -22.9444 -9.75551 10
-      vertex -22.2691 -9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.1123 10.5359 10
-      vertex -20 0 10
-      vertex -23.5668 10.0882 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20 0 10
-      vertex -23.5668 -10.0882 10
-      vertex -22.9444 -9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.1123 -10.5359 10
-      vertex -20 0 10
-      vertex -24.1123 10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20 0 10
-      vertex -24.1123 -10.5359 10
-      vertex -23.5668 -10.0882 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 11.0814 10
-      vertex -24.1123 -10.5359 10
-      vertex -24.1123 10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 11.0814 10
-      vertex -24.56 -11.0814 10
-      vertex -24.1123 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 11.7038 10
-      vertex -24.56 -11.0814 10
-      vertex -24.56 11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 11.7038 10
-      vertex -24.8927 -11.7038 10
-      vertex -24.56 -11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 12.3792 10
-      vertex -24.8927 -11.7038 10
-      vertex -24.8927 11.7038 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 12.3792 10
-      vertex -25.0976 -12.3792 10
-      vertex -24.8927 -11.7038 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.4558 14.8492 10
-      vertex -25.0976 12.3792 10
-      vertex -25.1668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 12.3792 10
-      vertex -25.4558 14.8492 10
-      vertex -25.0976 -12.3792 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -9.55065 20.8644 10
-      vertex -5.17638 19.3185 10
-      vertex -9.48148 21.5668 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -9.75551 20.1891 10
-      vertex -5.17638 19.3185 10
-      vertex -9.55065 20.8644 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -10.0882 19.5667 10
-      vertex -5.17638 19.3185 10
-      vertex -9.75551 20.1891 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.17638 19.3185 10
-      vertex -10.0882 19.5667 10
-      vertex -10 17.3205 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -10.5359 19.0212 10
-      vertex -10 17.3205 10
-      vertex -10.0882 19.5667 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.0814 18.5735 10
-      vertex -10 17.3205 10
-      vertex -10.5359 19.0212 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.7038 18.2408 10
-      vertex -10 17.3205 10
-      vertex -11.0814 18.5735 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.3792 18.0359 10
-      vertex -10 17.3205 10
-      vertex -11.7038 18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1421 14.1421 10
-      vertex -12.3792 18.0359 10
-      vertex -13.0815 17.9668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1421 14.1421 10
-      vertex -13.0815 17.9668 10
-      vertex -13.7838 18.0359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 18.0359 10
-      vertex -14.1421 14.1421 10
-      vertex -10 17.3205 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9265 17.0461 10
-      vertex -13.7838 18.0359 10
-      vertex -14.4591 18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9265 17.6021 10
-      vertex -14.4591 18.2408 10
-      vertex -15.0815 18.5735 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1393 18.1158 10
-      vertex -15.0815 18.5735 10
-      vertex -15.6271 19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4591 18.2408 10
-      vertex -15.8991 17.3241 10
-      vertex -15.9265 17.0461 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7838 18.0359 10
-      vertex -15.9265 17.0461 10
-      vertex -16.0076 16.7788 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7838 18.0359 10
-      vertex -16.0076 16.7788 10
-      vertex -14.1421 14.1421 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.1393 16.5324 10
-      vertex -14.1421 14.1421 10
-      vertex -16.0076 16.7788 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.3165 16.3165 10
-      vertex -14.1421 14.1421 10
-      vertex -16.1393 16.5324 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.5324 16.1393 10
-      vertex -14.1421 14.1421 10
-      vertex -16.3165 16.3165 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.7788 16.0076 10
-      vertex -14.1421 14.1421 10
-      vertex -16.5324 16.1393 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 13.7838 10
-      vertex -16.7788 16.0076 10
-      vertex -17.0461 15.9265 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 13.7838 10
-      vertex -14.1421 14.1421 10
-      vertex -16.7788 16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 13.7838 10
-      vertex -17.0461 15.9265 10
-      vertex -17.3241 15.8991 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 13.7838 10
-      vertex -17.3241 15.8991 10
-      vertex -17.6021 15.9265 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5735 15.0815 10
-      vertex -17.6021 15.9265 10
-      vertex -17.8694 16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0359 12.3792 10
-      vertex -14.1421 14.1421 10
-      vertex -17.9668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1421 14.1421 10
-      vertex -18.0359 12.3792 10
-      vertex -17.3205 10 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.2408 11.7038 10
-      vertex -17.3205 10 10
-      vertex -18.0359 12.3792 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.5735 11.0814 10
-      vertex -17.3205 10 10
-      vertex -18.2408 11.7038 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.0212 10.5359 10
-      vertex -17.3205 10 10
-      vertex -18.5735 11.0814 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.5667 10.0882 10
-      vertex -17.3205 10 10
-      vertex -19.0212 10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.3205 10 10
-      vertex -19.5667 10.0882 10
-      vertex -19.3185 5.17638 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.1891 9.75551 10
-      vertex -19.3185 5.17638 10
-      vertex -19.5667 10.0882 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.8644 9.55065 10
-      vertex -19.3185 5.17638 10
-      vertex -20.1891 9.75551 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.0076 -17.8694 10
-      vertex -15.0815 -18.5735 10
-      vertex -15.9265 -17.6021 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.1393 -18.1158 10
-      vertex -15.0815 -18.5735 10
-      vertex -16.0076 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0815 -18.5735 10
-      vertex -16.1393 -18.1158 10
-      vertex -15.6271 -19.0212 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.3165 -18.3317 10
-      vertex -15.6271 -19.0212 10
-      vertex -16.1393 -18.1158 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.5324 -18.509 10
-      vertex -15.6271 -19.0212 10
-      vertex -16.3165 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6271 -19.0212 10
-      vertex -16.5324 -18.509 10
-      vertex -16.0748 -19.5667 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.7788 -18.6406 10
-      vertex -16.0748 -19.5667 10
-      vertex -16.5324 -18.509 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.0461 -18.7217 10
-      vertex -16.0748 -19.5667 10
-      vertex -16.7788 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 -19.5667 10
-      vertex -17.0461 -18.7217 10
-      vertex -16.4074 -20.1891 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.3241 -18.7491 10
-      vertex -16.4074 -20.1891 10
-      vertex -17.0461 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.1158 -18.509 10
-      vertex 16.6123 -20.8644 10
-      vertex 16.6815 -21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 -19.5667 10
-      vertex 16.7788 -18.6406 10
-      vertex 16.5324 -18.509 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.0461 -18.7217 10
-      vertex 16.4074 -20.1891 10
-      vertex 16.6123 -20.8644 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 -19.0212 10
-      vertex 16.5324 -18.509 10
-      vertex 16.3165 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6271 -19.0212 10
-      vertex 16.3165 -18.3317 10
-      vertex 16.1393 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.0461 -18.7217 10
-      vertex 16.0748 -19.5667 10
-      vertex 16.4074 -20.1891 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 -18.5735 10
-      vertex 16.1393 -18.1158 10
-      vertex 16.0076 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.0815 -18.5735 10
-      vertex 16.0076 -17.8694 10
-      vertex 15.9265 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 -18.2408 10
-      vertex 15.9265 -17.6021 10
-      vertex 15.8991 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.5324 -18.509 10
-      vertex 15.6271 -19.0212 10
-      vertex 16.0748 -19.5667 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.3241 18.7491 10
-      vertex 16.4074 20.1891 10
-      vertex 17.0461 18.7217 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.0748 19.5667 10
-      vertex 17.0461 18.7217 10
-      vertex 16.4074 20.1891 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.0461 18.7217 10
-      vertex 16.0748 19.5667 10
-      vertex 16.7788 18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7788 18.6406 10
-      vertex 16.0748 19.5667 10
-      vertex 16.5324 18.509 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.6271 19.0212 10
-      vertex 16.5324 18.509 10
-      vertex 16.0748 19.5667 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.5324 18.509 10
-      vertex 15.6271 19.0212 10
-      vertex 16.3165 18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3165 18.3317 10
-      vertex 15.6271 19.0212 10
-      vertex 16.1393 18.1158 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.0815 18.5735 10
-      vertex 16.1393 18.1158 10
-      vertex 15.6271 19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1393 18.1158 10
-      vertex 15.0815 18.5735 10
-      vertex 16.0076 17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0076 17.8694 10
-      vertex 15.0815 18.5735 10
-      vertex 15.9265 17.6021 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 -16.4074 10
-      vertex 18.7217 -17.0461 10
-      vertex 18.7491 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 -16.0748 10
-      vertex 18.6406 -16.7788 10
-      vertex 18.7217 -17.0461 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.1158 -16.1393 10
-      vertex 19.0212 -15.6271 10
-      vertex 18.5735 -15.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 -16.0748 10
-      vertex 18.509 -16.5324 10
-      vertex 18.6406 -16.7788 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 -15.6271 10
-      vertex 18.3317 -16.3165 10
-      vertex 18.509 -16.5324 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6021 -15.9265 10
-      vertex 18.5735 -15.0815 10
-      vertex 18.2408 -14.4591 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 -15.6271 10
-      vertex 18.1158 -16.1393 10
-      vertex 18.3317 -16.3165 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.0461 -15.9265 10
-      vertex 18.2408 -14.4591 10
-      vertex 18.0359 -13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 -14.1421 10
-      vertex 18.0359 -13.7838 10
-      vertex 17.9668 -13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 -15.0815 10
-      vertex 17.8694 -16.0076 10
-      vertex 18.1158 -16.1393 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.0976 -12.3792 10
-      vertex 25.4558 -14.8492 10
-      vertex 25.0976 12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 -14.8492 10
-      vertex 25.0976 -12.3792 10
-      vertex 25.1668 -13.0815 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.8927 11.7038 10
-      vertex 25.0976 -12.3792 10
-      vertex 25.0976 12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8927 11.7038 10
-      vertex 24.8927 -11.7038 10
-      vertex 25.0976 -12.3792 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.56 11.0814 10
-      vertex 24.8927 -11.7038 10
-      vertex 24.8927 11.7038 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 11.0814 10
-      vertex 24.56 -11.0814 10
-      vertex 24.8927 -11.7038 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.1123 10.5359 10
-      vertex 24.56 -11.0814 10
-      vertex 24.56 11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 10.5359 10
-      vertex 24.1123 -10.5359 10
-      vertex 24.56 -11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20 0 10
-      vertex 24.1123 10.5359 10
-      vertex 23.5668 10.0882 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 10.5359 10
-      vertex 20 0 10
-      vertex 24.1123 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20 0 10
-      vertex 23.5668 10.0882 10
-      vertex 22.9444 9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 -10.5359 10
-      vertex 20 0 10
-      vertex 23.5668 -10.0882 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 22.9444 9.75551 10
-      vertex 22.2691 9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 -10.0882 10
-      vertex 20 0 10
-      vertex 22.9444 -9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 22.2691 9.55065 10
-      vertex 21.5668 9.48148 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.3185 -5.17638 10
-      vertex 22.9444 -9.75551 10
-      vertex 20 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 21.5668 9.48148 10
-      vertex 20.8644 9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 -9.75551 10
-      vertex 19.3185 -5.17638 10
-      vertex 22.2691 -9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 20.8644 9.55065 10
-      vertex 20.1891 9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2691 -9.55065 10
-      vertex 19.3185 -5.17638 10
-      vertex 21.5668 -9.48148 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 -9.48148 10
-      vertex 19.3185 -5.17638 10
-      vertex 20.8644 -9.55065 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 20.1891 9.75551 10
-      vertex 19.5667 10.0882 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 9.75551 10
-      vertex 19.3185 5.17638 10
-      vertex 20 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.3205 10 10
-      vertex 19.5667 10.0882 10
-      vertex 19.0212 10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.3205 10 10
-      vertex 19.0212 10.5359 10
-      vertex 18.5735 11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.3205 10 10
-      vertex 18.5735 11.0814 10
-      vertex 18.2408 11.7038 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.3205 10 10
-      vertex 18.2408 11.7038 10
-      vertex 18.0359 12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.0461 15.9265 10
-      vertex 18.2408 14.4591 10
-      vertex 17.3241 15.8991 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 14.4591 10
-      vertex 17.0461 15.9265 10
-      vertex 18.0359 13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7788 16.0076 10
-      vertex 18.0359 13.7838 10
-      vertex 17.0461 15.9265 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 18.0359 13.7838 10
-      vertex 16.7788 16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 10.0882 10
-      vertex 17.3205 10 10
-      vertex 19.3185 5.17638 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9668 13.0815 10
-      vertex 14.1421 14.1421 10
-      vertex 18.0359 12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 13.7838 10
-      vertex 14.1421 14.1421 10
-      vertex 17.9668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 16.7788 16.0076 10
-      vertex 16.5324 16.1393 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 16.5324 16.1393 10
-      vertex 16.3165 16.3165 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 16.3165 16.3165 10
-      vertex 16.1393 16.5324 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 16.1393 16.5324 10
-      vertex 16.0076 16.7788 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7838 18.0359 10
-      vertex 16.0076 16.7788 10
-      vertex 15.9265 17.0461 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.4591 18.2408 10
-      vertex 15.9265 17.6021 10
-      vertex 15.0815 18.5735 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9265 17.6021 10
-      vertex 14.4591 18.2408 10
-      vertex 15.8991 17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.8991 17.3241 10
-      vertex 14.4591 18.2408 10
-      vertex 15.9265 17.0461 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7838 18.0359 10
-      vertex 15.9265 17.0461 10
-      vertex 14.4591 18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 12.3792 10
-      vertex 14.1421 14.1421 10
-      vertex 17.3205 10 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0076 16.7788 10
-      vertex 13.7838 18.0359 10
-      vertex 14.1421 14.1421 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0815 17.9668 10
-      vertex 14.1421 14.1421 10
-      vertex 13.7838 18.0359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 18.0359 10
-      vertex 14.1421 14.1421 10
-      vertex 13.0815 17.9668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 17.3205 10
-      vertex 12.3792 18.0359 10
-      vertex 11.7038 18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 17.3205 10
-      vertex 11.7038 18.2408 10
-      vertex 11.0814 18.5735 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 17.3205 10
-      vertex 11.0814 18.5735 10
-      vertex 10.5359 19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 17.3205 10
-      vertex 10.5359 19.0212 10
-      vertex 10.0882 19.5667 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 18.0359 10
-      vertex 10 17.3205 10
-      vertex 14.1421 14.1421 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.17638 19.3185 10
-      vertex 10.0882 19.5667 10
-      vertex 9.75551 20.1891 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.17638 19.3185 10
-      vertex 9.75551 20.1891 10
-      vertex 9.55065 20.8644 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.0882 19.5667 10
-      vertex 5.17638 19.3185 10
-      vertex 10 17.3205 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.17638 19.3185 10
-      vertex 9.55065 20.8644 10
-      vertex 9.48148 21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.0976 12.3792 10
-      vertex 25.4558 14.8492 10
-      vertex 25.1668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 25.0976 13.7838 10
-      vertex 25.1668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 24.8927 14.4591 10
-      vertex 25.0976 13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 24.56 15.0815 10
-      vertex 24.8927 14.4591 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 24.1123 15.6271 10
-      vertex 24.56 15.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 23.5668 16.0748 10
-      vertex 24.1123 15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 16.4074 10
-      vertex 18.7217 17.0461 10
-      vertex 19.5667 16.0748 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.7217 17.0461 10
-      vertex 20.1891 16.4074 10
-      vertex 18.7491 17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7217 17.6021 10
-      vertex 20.1891 16.4074 10
-      vertex 20.8644 16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.509 18.1158 10
-      vertex 20.8644 16.6123 10
-      vertex 21.5668 16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3317 18.3317 10
-      vertex 21.5668 16.6815 10
-      vertex 22.2691 16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 16.4074 10
-      vertex 18.7217 17.6021 10
-      vertex 18.7491 17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 16.6123 10
-      vertex 18.6406 17.8694 10
-      vertex 18.7217 17.6021 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 22.2691 10
-      vertex 22.2691 16.6123 10
-      vertex 22.9444 16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 16.6123 10
-      vertex 18.509 18.1158 10
-      vertex 18.6406 17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5668 16.6815 10
-      vertex 18.3317 18.3317 10
-      vertex 18.509 18.1158 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2691 16.6123 10
-      vertex 16.6123 22.2691 10
-      vertex 18.3317 18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3317 18.3317 10
-      vertex 16.6815 21.5668 10
-      vertex 18.1158 18.509 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6021 18.7217 10
-      vertex 16.4074 20.1891 10
-      vertex 17.3241 18.7491 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.4074 20.1891 10
-      vertex 17.6021 18.7217 10
-      vertex 16.6123 20.8644 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.8694 18.6406 10
-      vertex 16.6123 20.8644 10
-      vertex 17.6021 18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.1158 18.509 10
-      vertex 16.6123 20.8644 10
-      vertex 17.8694 18.6406 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.6123 20.8644 10
-      vertex 18.1158 18.509 10
-      vertex 16.6815 21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 22.9444 10
-      vertex 22.9444 16.4074 10
-      vertex 23.5668 16.0748 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 23.5668 10
-      vertex 23.5668 16.0748 10
-      vertex 25.4558 14.8492 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3317 18.3317 10
-      vertex 16.6123 22.2691 10
-      vertex 16.6815 21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9444 16.4074 10
-      vertex 16.4074 22.9444 10
-      vertex 16.6123 22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 16.0748 10
-      vertex 16.0748 23.5668 10
-      vertex 16.4074 22.9444 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 16.0748 23.5668 10
-      vertex 25.4558 14.8492 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 23.5668 10
-      vertex 14.8492 25.4558 10
-      vertex 15.6271 24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 15.0815 24.56 10
-      vertex 15.6271 24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 14.4591 24.8927 10
-      vertex 15.0815 24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 13.7838 25.0976 10
-      vertex 14.4591 24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 13.0815 25.1668 10
-      vertex 13.7838 25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 25.4558 10
-      vertex 12.3792 25.0976 10
-      vertex 13.0815 25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.55065 22.2691 10
-      vertex 5.17638 19.3185 10
-      vertex 9.48148 21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.75551 22.9444 10
-      vertex 5.17638 19.3185 10
-      vertex 9.55065 22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 20 10
-      vertex 9.75551 22.9444 10
-      vertex 10.0882 23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 20 10
-      vertex 10.0882 23.5668 10
-      vertex 10.5359 24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.75551 22.9444 10
-      vertex 0 20 10
-      vertex 5.17638 19.3185 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 24.1123 10
-      vertex 10.5359 24.1123 10
-      vertex 11.0814 24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 24.56 10
-      vertex 11.0814 24.56 10
-      vertex 11.7038 24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5359 24.1123 10
-      vertex -10.5359 24.1123 10
-      vertex 0 20 10
-    endloop
-  endfacet
-  facet normal -0 -0 1
-    outer loop
-      vertex -9.75551 22.9444 10
-      vertex 0 20 10
-      vertex -10.0882 23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 24.8927 10
-      vertex 11.7038 24.8927 10
-      vertex 12.3792 25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.17638 19.3185 10
-      vertex -9.55065 22.2691 10
-      vertex -9.48148 21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 25.0976 10
-      vertex 12.3792 25.0976 10
-      vertex 14.8492 25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.17638 19.3185 10
-      vertex -9.75551 22.9444 10
-      vertex -9.55065 22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 20 10
-      vertex -9.75551 22.9444 10
-      vertex -5.17638 19.3185 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 20 10
-      vertex -10.5359 24.1123 10
-      vertex -10.0882 23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.0814 24.56 10
-      vertex -11.0814 24.56 10
-      vertex -10.5359 24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7038 24.8927 10
-      vertex -11.7038 24.8927 10
-      vertex -11.0814 24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 25.0976 10
-      vertex -12.3792 25.0976 10
-      vertex -11.7038 24.8927 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -12.3792 25.0976 10
-      vertex 14.8492 25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 25.0976 10
-      vertex -14.8492 25.4558 10
-      vertex -13.0815 25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -13.7838 25.0976 10
-      vertex -13.0815 25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -14.4591 24.8927 10
-      vertex -13.7838 25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -15.0815 24.56 10
-      vertex -14.4591 24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -15.6271 24.1123 10
-      vertex -15.0815 24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -16.0748 23.5668 10
-      vertex -15.6271 24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 19.5667 10
-      vertex -17.0461 18.7217 10
-      vertex -16.7788 18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3317 18.3317 10
-      vertex -16.6815 21.5668 10
-      vertex -16.6123 22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 20.1891 10
-      vertex -17.3241 18.7491 10
-      vertex -17.0461 18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 20.1891 10
-      vertex -17.6021 18.7217 10
-      vertex -17.3241 18.7491 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 20.8644 10
-      vertex -17.8694 18.6406 10
-      vertex -17.6021 18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 16.6123 10
-      vertex -16.6123 22.2691 10
-      vertex -16.4074 22.9444 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 20.8644 10
-      vertex -18.1158 18.509 10
-      vertex -17.8694 18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6815 21.5668 10
-      vertex -18.3317 18.3317 10
-      vertex -18.1158 18.509 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 22.2691 10
-      vertex -22.2691 16.6123 10
-      vertex -18.3317 18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3317 18.3317 10
-      vertex -21.5668 16.6815 10
-      vertex -18.509 18.1158 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1891 16.4074 10
-      vertex -18.7491 17.3241 10
-      vertex -18.7217 17.6021 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.509 16.5324 10
-      vertex -19.5667 16.0748 10
-      vertex -19.0212 15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8644 16.6123 10
-      vertex -18.7217 17.6021 10
-      vertex -18.6406 17.8694 10
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -20.8644 16.6123 10
-      vertex -18.509 18.1158 10
-      vertex -21.5668 16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.7217 17.0461 10
-      vertex -20.1891 16.4074 10
-      vertex -19.5667 16.0748 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.9444 16.4074 10
-      vertex -16.4074 22.9444 10
-      vertex -16.0748 23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.7217 17.6021 10
-      vertex -20.8644 16.6123 10
-      vertex -20.1891 16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 16.0748 10
-      vertex -16.0748 23.5668 10
-      vertex -14.8492 25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.509 18.1158 10
-      vertex -20.8644 16.6123 10
-      vertex -18.6406 17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3317 18.3317 10
-      vertex -22.2691 16.6123 10
-      vertex -21.5668 16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 22.9444 10
-      vertex -22.9444 16.4074 10
-      vertex -22.2691 16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 23.5668 10
-      vertex -23.5668 16.0748 10
-      vertex -22.9444 16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.4558 14.8492 10
-      vertex -23.5668 16.0748 10
-      vertex -14.8492 25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.4558 -14.8492 10
-      vertex -25.0976 -12.3792 10
-      vertex -25.4558 14.8492 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 13.7838 10
-      vertex -25.4558 14.8492 10
-      vertex -25.1668 13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 14.4591 10
-      vertex -25.4558 14.8492 10
-      vertex -25.0976 13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 15.0815 10
-      vertex -25.4558 14.8492 10
-      vertex -24.8927 14.4591 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.1123 15.6271 10
-      vertex -25.4558 14.8492 10
-      vertex -24.56 15.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 16.0748 10
-      vertex -25.4558 14.8492 10
-      vertex -24.1123 15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 25.0976 12.3792 10
-      vertex 25.4558 -14.8492 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.0976 -13.7838 10
-      vertex 25.4558 -14.8492 10
-      vertex 25.1668 -13.0815 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.8927 -14.4591 10
-      vertex 25.4558 -14.8492 10
-      vertex 25.0976 -13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.56 -15.0815 10
-      vertex 25.4558 -14.8492 10
-      vertex 24.8927 -14.4591 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.1123 -15.6271 10
-      vertex 25.4558 -14.8492 10
-      vertex 24.56 -15.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5668 -16.0748 10
-      vertex 25.4558 -14.8492 10
-      vertex 24.1123 -15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.509 -16.5324 10
-      vertex 19.5667 -16.0748 10
-      vertex 19.0212 -15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7217 -17.0461 10
-      vertex 20.1891 -16.4074 10
-      vertex 19.5667 -16.0748 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7217 -17.6021 10
-      vertex 20.1891 -16.4074 10
-      vertex 18.7491 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 -16.4074 10
-      vertex 18.7217 -17.6021 10
-      vertex 20.8644 -16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.6406 -17.8694 10
-      vertex 20.8644 -16.6123 10
-      vertex 18.7217 -17.6021 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.509 -18.1158 10
-      vertex 20.8644 -16.6123 10
-      vertex 18.6406 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 -16.6123 10
-      vertex 18.509 -18.1158 10
-      vertex 21.5668 -16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3317 -18.3317 10
-      vertex 21.5668 -16.6815 10
-      vertex 18.509 -18.1158 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.5668 -16.6815 10
-      vertex 18.3317 -18.3317 10
-      vertex 22.2691 -16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -22.2691 10
-      vertex 22.2691 -16.6123 10
-      vertex 18.3317 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6815 -21.5668 10
-      vertex 18.3317 -18.3317 10
-      vertex 18.1158 -18.509 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -20.8644 10
-      vertex 18.1158 -18.509 10
-      vertex 17.8694 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 -19.5667 10
-      vertex 17.0461 -18.7217 10
-      vertex 16.7788 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -20.8644 10
-      vertex 17.3241 -18.7491 10
-      vertex 17.0461 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -20.8644 10
-      vertex 17.6021 -18.7217 10
-      vertex 17.3241 -18.7491 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -20.8644 10
-      vertex 17.8694 -18.6406 10
-      vertex 17.6021 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6123 -22.2691 10
-      vertex 18.3317 -18.3317 10
-      vertex 16.6815 -21.5668 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.2691 -16.6123 10
-      vertex 16.6123 -22.2691 10
-      vertex 22.9444 -16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.4074 -22.9444 10
-      vertex 22.9444 -16.4074 10
-      vertex 16.6123 -22.2691 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.9444 -16.4074 10
-      vertex 16.4074 -22.9444 10
-      vertex 23.5668 -16.0748 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0748 -23.5668 10
-      vertex 23.5668 -16.0748 10
-      vertex 16.4074 -22.9444 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.5668 -16.0748 10
-      vertex 16.0748 -23.5668 10
-      vertex 25.4558 -14.8492 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8492 -25.4558 10
-      vertex 16.0748 -23.5668 10
-      vertex 15.6271 -24.1123 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.0748 -23.5668 10
-      vertex 14.8492 -25.4558 10
-      vertex 25.4558 -14.8492 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.0815 -24.56 10
-      vertex 14.8492 -25.4558 10
-      vertex 15.6271 -24.1123 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.4591 -24.8927 10
-      vertex 14.8492 -25.4558 10
-      vertex 15.0815 -24.56 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7838 -25.0976 10
-      vertex 14.8492 -25.4558 10
-      vertex 14.4591 -24.8927 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0815 -25.1668 10
-      vertex 14.8492 -25.4558 10
-      vertex 13.7838 -25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 -25.0976 10
-      vertex 14.8492 -25.4558 10
-      vertex 13.0815 -25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.17638 -19.3185 10
-      vertex 9.55065 -22.2691 10
-      vertex 9.48148 -21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.17638 -19.3185 10
-      vertex 9.75551 -22.9444 10
-      vertex 9.55065 -22.2691 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0 -20 10
-      vertex 9.75551 -22.9444 10
-      vertex 5.17638 -19.3185 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.75551 -22.9444 10
-      vertex 0 -20 10
-      vertex 10.0882 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.0882 -23.5668 10
-      vertex 0 -20 10
-      vertex 10.5359 -24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 -24.1123 10
-      vertex 10.5359 -24.1123 10
-      vertex 0 -20 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5359 -24.1123 10
-      vertex -10.5359 -24.1123 10
-      vertex 11.0814 -24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.75551 -22.9444 10
-      vertex 0 -20 10
-      vertex -5.17638 -19.3185 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.55065 -22.2691 10
-      vertex -5.17638 -19.3185 10
-      vertex -9.48148 -21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.75551 -22.9444 10
-      vertex -5.17638 -19.3185 10
-      vertex -9.55065 -22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 -20 10
-      vertex -9.75551 -22.9444 10
-      vertex -10.0882 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5359 -24.1123 10
-      vertex 0 -20 10
-      vertex -10.0882 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.0814 -24.56 10
-      vertex 11.0814 -24.56 10
-      vertex -10.5359 -24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.0814 -24.56 10
-      vertex -11.0814 -24.56 10
-      vertex 11.7038 -24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7038 -24.8927 10
-      vertex 11.7038 -24.8927 10
-      vertex -11.0814 -24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7038 -24.8927 10
-      vertex -11.7038 -24.8927 10
-      vertex 12.3792 -25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 -25.0976 10
-      vertex 12.3792 -25.0976 10
-      vertex -11.7038 -24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 -25.0976 10
-      vertex -12.3792 -25.0976 10
-      vertex 14.8492 -25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8492 -25.4558 10
-      vertex -12.3792 -25.0976 10
-      vertex -13.0815 -25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3792 -25.0976 10
-      vertex -14.8492 -25.4558 10
-      vertex 14.8492 -25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.7838 -25.0976 10
-      vertex -14.8492 -25.4558 10
-      vertex -13.0815 -25.1668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4591 -24.8927 10
-      vertex -14.8492 -25.4558 10
-      vertex -13.7838 -25.0976 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0815 -24.56 10
-      vertex -14.8492 -25.4558 10
-      vertex -14.4591 -24.8927 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6271 -24.1123 10
-      vertex -14.8492 -25.4558 10
-      vertex -15.0815 -24.56 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 -23.5668 10
-      vertex -14.8492 -25.4558 10
-      vertex -15.6271 -24.1123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.6021 -18.7217 10
-      vertex -16.4074 -20.1891 10
-      vertex -17.3241 -18.7491 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 -20.1891 10
-      vertex -17.6021 -18.7217 10
-      vertex -16.6123 -20.8644 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.8694 -18.6406 10
-      vertex -16.6123 -20.8644 10
-      vertex -17.6021 -18.7217 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.1158 -18.509 10
-      vertex -16.6123 -20.8644 10
-      vertex -17.8694 -18.6406 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 -20.8644 10
-      vertex -18.1158 -18.509 10
-      vertex -16.6815 -21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3317 -18.3317 10
-      vertex -16.6815 -21.5668 10
-      vertex -18.1158 -18.509 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6815 -21.5668 10
-      vertex -18.3317 -18.3317 10
-      vertex -16.6123 -22.2691 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 -16.6123 10
-      vertex -16.6123 -22.2691 10
-      vertex -18.3317 -18.3317 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5668 -16.6815 10
-      vertex -18.3317 -18.3317 10
-      vertex -18.509 -18.1158 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8644 -16.6123 10
-      vertex -18.509 -18.1158 10
-      vertex -18.6406 -17.8694 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.1891 -16.4074 10
-      vertex -18.7217 -17.0461 10
-      vertex -19.5667 -16.0748 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.7217 -17.0461 10
-      vertex -20.1891 -16.4074 10
-      vertex -18.7491 -17.3241 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.7491 -17.3241 10
-      vertex -20.1891 -16.4074 10
-      vertex -18.7217 -17.6021 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.8644 -16.6123 10
-      vertex -18.7217 -17.6021 10
-      vertex -20.1891 -16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.7217 -17.6021 10
-      vertex -20.8644 -16.6123 10
-      vertex -18.6406 -17.8694 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.509 -18.1158 10
-      vertex -20.8644 -16.6123 10
-      vertex -21.5668 -16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2691 -16.6123 10
-      vertex -18.3317 -18.3317 10
-      vertex -21.5668 -16.6815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6123 -22.2691 10
-      vertex -22.2691 -16.6123 10
-      vertex -16.4074 -22.9444 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.9444 -16.4074 10
-      vertex -16.4074 -22.9444 10
-      vertex -22.2691 -16.6123 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4074 -22.9444 10
-      vertex -22.9444 -16.4074 10
-      vertex -16.0748 -23.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 -16.0748 10
-      vertex -16.0748 -23.5668 10
-      vertex -22.9444 -16.4074 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0748 -23.5668 10
-      vertex -23.5668 -16.0748 10
-      vertex -14.8492 -25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.4558 -14.8492 10
-      vertex -23.5668 -16.0748 10
-      vertex -24.1123 -15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.5668 -16.0748 10
-      vertex -25.4558 -14.8492 10
-      vertex -14.8492 -25.4558 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.56 -15.0815 10
-      vertex -25.4558 -14.8492 10
-      vertex -24.1123 -15.6271 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8927 -14.4591 10
-      vertex -25.4558 -14.8492 10
-      vertex -24.56 -15.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 -13.7838 10
-      vertex -25.4558 -14.8492 10
-      vertex -24.8927 -14.4591 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.1668 -13.0815 10
-      vertex -25.4558 -14.8492 10
-      vertex -25.0976 -13.7838 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.0976 -12.3792 10
-      vertex -25.4558 -14.8492 10
-      vertex -25.1668 -13.0815 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8644 -9.55065 10
-      vertex 19.3185 -5.17638 10
-      vertex 20.1891 -9.75551 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1891 -9.75551 10
-      vertex 19.3185 -5.17638 10
-      vertex 19.5667 -10.0882 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.3205 -10 10
-      vertex 19.5667 -10.0882 10
-      vertex 19.3185 -5.17638 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 -10.0882 10
-      vertex 17.3205 -10 10
-      vertex 19.0212 -10.5359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 -10.5359 10
-      vertex 17.3205 -10 10
-      vertex 18.5735 -11.0814 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 -11.0814 10
-      vertex 17.3205 -10 10
-      vertex 18.2408 -11.7038 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 -15.0815 10
-      vertex 17.6021 -15.9265 10
-      vertex 17.8694 -16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 -14.1421 10
-      vertex 17.9668 -13.0815 10
-      vertex 18.0359 -12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 -14.4591 10
-      vertex 17.3241 -15.8991 10
-      vertex 17.6021 -15.9265 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 -11.7038 10
-      vertex 17.3205 -10 10
-      vertex 18.0359 -12.3792 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 -14.1421 10
-      vertex 18.0359 -12.3792 10
-      vertex 17.3205 -10 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2408 -14.4591 10
-      vertex 17.0461 -15.9265 10
-      vertex 17.3241 -15.8991 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 -13.7838 10
-      vertex 14.1421 -14.1421 10
-      vertex 16.7788 -16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0359 -13.7838 10
-      vertex 16.7788 -16.0076 10
-      vertex 17.0461 -15.9265 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7788 -16.0076 10
-      vertex 14.1421 -14.1421 10
-      vertex 16.5324 -16.1393 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.5324 -16.1393 10
-      vertex 14.1421 -14.1421 10
-      vertex 16.3165 -16.3165 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3165 -16.3165 10
-      vertex 14.1421 -14.1421 10
-      vertex 16.1393 -16.5324 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1393 -16.5324 10
-      vertex 14.1421 -14.1421 10
-      vertex 16.0076 -16.7788 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4591 -18.2408 10
-      vertex 15.8991 -17.3241 10
-      vertex 15.9265 -17.0461 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1393 -18.1158 10
-      vertex 15.0815 -18.5735 10
-      vertex 15.6271 -19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7838 -18.0359 10
-      vertex 16.0076 -16.7788 10
-      vertex 14.1421 -14.1421 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0076 -16.7788 10
-      vertex 13.7838 -18.0359 10
-      vertex 15.9265 -17.0461 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9265 -17.6021 10
-      vertex 14.4591 -18.2408 10
-      vertex 15.0815 -18.5735 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9265 -17.0461 10
-      vertex 13.7838 -18.0359 10
-      vertex 14.4591 -18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 -14.1421 10
-      vertex 13.0815 -17.9668 10
-      vertex 13.7838 -18.0359 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1421 -14.1421 10
-      vertex 12.3792 -18.0359 10
-      vertex 13.0815 -17.9668 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10 -17.3205 10
-      vertex 12.3792 -18.0359 10
-      vertex 14.1421 -14.1421 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.3792 -18.0359 10
-      vertex 10 -17.3205 10
-      vertex 11.7038 -18.2408 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7038 -18.2408 10
-      vertex 10 -17.3205 10
-      vertex 11.0814 -18.5735 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.0814 -18.5735 10
-      vertex 10 -17.3205 10
-      vertex 10.5359 -19.0212 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5359 -19.0212 10
-      vertex 10 -17.3205 10
-      vertex 10.0882 -19.5667 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 5.17638 -19.3185 10
-      vertex 10.0882 -19.5667 10
-      vertex 10 -17.3205 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.0882 -19.5667 10
-      vertex 5.17638 -19.3185 10
-      vertex 9.75551 -20.1891 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.55065 -20.8644 10
-      vertex 5.17638 -19.3185 10
-      vertex 9.48148 -21.5668 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.75551 -20.1891 10
-      vertex 5.17638 -19.3185 10
-      vertex 9.55065 -20.8644 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.6406 16.7788 10
-      vertex 19.5667 16.0748 10
-      vertex 18.7217 17.0461 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.509 16.5324 10
-      vertex 19.5667 16.0748 10
-      vertex 18.6406 16.7788 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5667 16.0748 10
-      vertex 18.509 16.5324 10
-      vertex 19.0212 15.6271 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.3317 16.3165 10
-      vertex 19.0212 15.6271 10
-      vertex 18.509 16.5324 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.1158 16.1393 10
-      vertex 19.0212 15.6271 10
-      vertex 18.3317 16.3165 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0212 15.6271 10
-      vertex 18.1158 16.1393 10
-      vertex 18.5735 15.0815 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.8694 16.0076 10
-      vertex 18.5735 15.0815 10
-      vertex 18.1158 16.1393 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.6021 15.9265 10
-      vertex 18.5735 15.0815 10
-      vertex 17.8694 16.0076 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5735 15.0815 10
-      vertex 17.6021 15.9265 10
-      vertex 18.2408 14.4591 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.3241 15.8991 10
-      vertex 18.2408 14.4591 10
-      vertex 17.6021 15.9265 10
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 0
-    outer loop
-      vertex 25.4558 14.8492 10
-      vertex 14.8492 25.4558 0
-      vertex 14.8492 25.4558 10
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 0
-    outer loop
-      vertex 14.8492 25.4558 0
-      vertex 25.4558 14.8492 10
-      vertex 25.4558 14.8492 0
+      vertex 18.2596 -15.7648 10
+      vertex 18.1308 -15.6442 0
+      vertex 18.2596 -15.7648 0
     endloop
   endfacet
   facet normal 0.707107 -0.707107 0
     outer loop
-      vertex 14.8492 -25.4558 10
-      vertex 25.4558 -14.8492 0
-      vertex 25.4558 -14.8492 10
+      vertex 15.6815 -16.9895 10
+      vertex 16.9895 -15.6815 0
+      vertex 16.9895 -15.6815 10
     endloop
   endfacet
   facet normal 0.707107 -0.707107 0
     outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 14.8492 -25.4558 10
-      vertex 14.8492 -25.4558 0
+      vertex 16.9895 -15.6815 0
+      vertex 15.6815 -16.9895 10
+      vertex 15.6815 -16.9895 0
+    endloop
+  endfacet
+  facet normal 0.412708 -0.910863 0
+    outer loop
+      vertex 17.1329 -15.5788 0
+      vertex 17.2936 -15.506 10
+      vertex 17.1329 -15.5788 10
+    endloop
+  endfacet
+  facet normal 0.412708 -0.910863 0
+    outer loop
+      vertex 17.2936 -15.506 10
+      vertex 17.1329 -15.5788 0
+      vertex 17.2936 -15.506 0
+    endloop
+  endfacet
+  facet normal 0.582482 -0.812844 0
+    outer loop
+      vertex 16.9895 -15.6815 0
+      vertex 17.1329 -15.5788 10
+      vertex 16.9895 -15.6815 10
+    endloop
+  endfacet
+  facet normal 0.582482 -0.812844 0
+    outer loop
+      vertex 17.1329 -15.5788 10
+      vertex 16.9895 -15.6815 0
+      vertex 17.1329 -15.5788 0
+    endloop
+  endfacet
+  facet normal -0.162896 -0.986643 0
+    outer loop
+      vertex 17.6418 -15.4601 0
+      vertex 17.8159 -15.4889 10
+      vertex 17.6418 -15.4601 10
+    endloop
+  endfacet
+  facet normal -0.162896 -0.986643 -0
+    outer loop
+      vertex 17.8159 -15.4889 10
+      vertex 17.6418 -15.4601 0
+      vertex 17.8159 -15.4889 0
+    endloop
+  endfacet
+  facet normal 0.999465 -0.0327187 0
+    outer loop
+      vertex 15.4601 -17.6418 10
+      vertex 15.4659 -17.4655 0
+      vertex 15.4659 -17.4655 10
+    endloop
+  endfacet
+  facet normal 0.999465 -0.0327187 0
+    outer loop
+      vertex 15.4659 -17.4655 0
+      vertex 15.4601 -17.6418 10
+      vertex 15.4601 -17.6418 0
+    endloop
+  endfacet
+  facet normal 0.910863 -0.412708 0
+    outer loop
+      vertex 15.506 -17.2936 10
+      vertex 15.5788 -17.1329 0
+      vertex 15.5788 -17.1329 10
+    endloop
+  endfacet
+  facet normal 0.910863 -0.412708 0
+    outer loop
+      vertex 15.5788 -17.1329 0
+      vertex 15.506 -17.2936 10
+      vertex 15.506 -17.2936 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980094 0
+    outer loop
+      vertex 18.9312 -18.0312 0
+      vertex 18.9139 -17.8556 10
+      vertex 18.9139 -17.8556 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980094 0
+    outer loop
+      vertex 18.9139 -17.8556 10
+      vertex 18.9312 -18.0312 0
+      vertex 18.9312 -18.0312 10
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex 18.9139 -17.8556 0
+      vertex 18.4352 -16.0689 10
+      vertex 18.4352 -16.0689 0
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex 18.4352 -16.0689 10
+      vertex 18.9139 -17.8556 0
+      vertex 18.9139 -17.8556 10
+    endloop
+  endfacet
+  facet normal 0.227075 -0.973877 0
+    outer loop
+      vertex 17.2936 -15.506 0
+      vertex 17.4655 -15.4659 10
+      vertex 17.2936 -15.506 10
+    endloop
+  endfacet
+  facet normal 0.227075 -0.973877 0
+    outer loop
+      vertex 17.4655 -15.4659 10
+      vertex 17.2936 -15.506 0
+      vertex 17.4655 -15.4659 0
+    endloop
+  endfacet
+  facet normal -0.528066 -0.849204 0
+    outer loop
+      vertex 17.981 -15.551 0
+      vertex 18.1308 -15.6442 10
+      vertex 17.981 -15.551 10
+    endloop
+  endfacet
+  facet normal -0.528066 -0.849204 -0
+    outer loop
+      vertex 18.1308 -15.6442 10
+      vertex 17.981 -15.551 0
+      vertex 18.1308 -15.6442 0
+    endloop
+  endfacet
+  facet normal 0.973877 -0.227075 0
+    outer loop
+      vertex 15.4659 -17.4655 10
+      vertex 15.506 -17.2936 0
+      vertex 15.506 -17.2936 10
+    endloop
+  endfacet
+  facet normal 0.973877 -0.227075 0
+    outer loop
+      vertex 15.506 -17.2936 0
+      vertex 15.4659 -17.4655 10
+      vertex 15.4659 -17.4655 0
+    endloop
+  endfacet
+  facet normal 0.812844 -0.582482 0
+    outer loop
+      vertex 15.5788 -17.1329 10
+      vertex 15.6815 -16.9895 0
+      vertex 15.6815 -16.9895 10
+    endloop
+  endfacet
+  facet normal 0.812844 -0.582482 0
+    outer loop
+      vertex 15.6815 -16.9895 0
+      vertex 15.5788 -17.1329 10
+      vertex 15.5788 -17.1329 0
+    endloop
+  endfacet
+  facet normal 0.849204 0.528066 0
+    outer loop
+      vertex 15.6442 -18.1308 10
+      vertex 15.551 -17.981 0
+      vertex 15.551 -17.981 10
+    endloop
+  endfacet
+  facet normal 0.849204 0.528066 0
+    outer loop
+      vertex 15.551 -17.981 0
+      vertex 15.6442 -18.1308 10
+      vertex 15.6442 -18.1308 0
+    endloop
+  endfacet
+  facet normal 0.986643 0.162896 0
+    outer loop
+      vertex 15.4889 -17.8159 10
+      vertex 15.4601 -17.6418 0
+      vertex 15.4601 -17.6418 10
+    endloop
+  endfacet
+  facet normal 0.986643 0.162896 0
+    outer loop
+      vertex 15.4601 -17.6418 0
+      vertex 15.4889 -17.8159 10
+      vertex 15.4889 -17.8159 0
+    endloop
+  endfacet
+  facet normal 0.412705 0.910865 -0
+    outer loop
+      vertex 16.0689 -18.4352 0
+      vertex 15.9082 -18.3624 10
+      vertex 16.0689 -18.4352 10
+    endloop
+  endfacet
+  facet normal 0.412705 0.910865 0
+    outer loop
+      vertex 15.9082 -18.3624 10
+      vertex 16.0689 -18.4352 0
+      vertex 15.9082 -18.3624 0
+    endloop
+  endfacet
+  facet normal 0.258819 0.965926 -0
+    outer loop
+      vertex 17.8556 -18.9139 0
+      vertex 16.0689 -18.4352 10
+      vertex 17.8556 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0.258819 0.965926 0
+    outer loop
+      vertex 16.0689 -18.4352 10
+      vertex 17.8556 -18.9139 0
+      vertex 16.0689 -18.4352 0
+    endloop
+  endfacet
+  facet normal -0.471394 0.881923 0
+    outer loop
+      vertex 18.5312 -18.7795 0
+      vertex 18.3756 -18.8627 10
+      vertex 18.5312 -18.7795 10
+    endloop
+  endfacet
+  facet normal -0.471394 0.881923 0
+    outer loop
+      vertex 18.3756 -18.8627 10
+      vertex 18.5312 -18.7795 0
+      vertex 18.3756 -18.8627 0
+    endloop
+  endfacet
+  facet normal -0.290291 0.956938 0
+    outer loop
+      vertex 18.3756 -18.8627 0
+      vertex 18.2068 -18.9139 10
+      vertex 18.3756 -18.8627 10
+    endloop
+  endfacet
+  facet normal -0.290291 0.956938 0
+    outer loop
+      vertex 18.2068 -18.9139 10
+      vertex 18.3756 -18.8627 0
+      vertex 18.2068 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0.0980094 0.995185 -0
+    outer loop
+      vertex 18.0312 -18.9312 0
+      vertex 17.8556 -18.9139 10
+      vertex 18.0312 -18.9312 10
+    endloop
+  endfacet
+  facet normal 0.0980094 0.995185 0
+    outer loop
+      vertex 17.8556 -18.9139 10
+      vertex 18.0312 -18.9312 0
+      vertex 17.8556 -18.9139 0
+    endloop
+  endfacet
+  facet normal -0.773009 0.634394 0
+    outer loop
+      vertex 18.6676 -18.6676 0
+      vertex 18.7795 -18.5312 10
+      vertex 18.7795 -18.5312 0
+    endloop
+  endfacet
+  facet normal -0.773009 0.634394 0
+    outer loop
+      vertex 18.7795 -18.5312 10
+      vertex 18.6676 -18.6676 0
+      vertex 18.6676 -18.6676 10
+    endloop
+  endfacet
+  facet normal -0.910865 -0.412705 0
+    outer loop
+      vertex 18.4352 -16.0689 0
+      vertex 18.3624 -15.9082 10
+      vertex 18.3624 -15.9082 0
+    endloop
+  endfacet
+  facet normal -0.910865 -0.412705 0
+    outer loop
+      vertex 18.3624 -15.9082 10
+      vertex 18.4352 -16.0689 0
+      vertex 18.4352 -16.0689 10
+    endloop
+  endfacet
+  facet normal 0.0327187 -0.999465 0
+    outer loop
+      vertex 17.4655 -15.4659 0
+      vertex 17.6418 -15.4601 10
+      vertex 17.4655 -15.4659 10
+    endloop
+  endfacet
+  facet normal 0.0327187 -0.999465 0
+    outer loop
+      vertex 17.6418 -15.4601 10
+      vertex 17.4655 -15.4659 0
+      vertex 17.6418 -15.4601 0
+    endloop
+  endfacet
+  facet normal -0.352251 -0.935906 0
+    outer loop
+      vertex 17.8159 -15.4889 0
+      vertex 17.981 -15.551 10
+      vertex 17.8159 -15.4889 10
+    endloop
+  endfacet
+  facet normal -0.352251 -0.935906 -0
+    outer loop
+      vertex 17.981 -15.551 10
+      vertex 17.8159 -15.4889 0
+      vertex 17.981 -15.551 0
+    endloop
+  endfacet
+  facet normal 0.935906 0.352251 0
+    outer loop
+      vertex 15.551 -17.981 10
+      vertex 15.4889 -17.8159 0
+      vertex 15.4889 -17.8159 10
+    endloop
+  endfacet
+  facet normal 0.935906 0.352251 0
+    outer loop
+      vertex 15.4889 -17.8159 0
+      vertex 15.551 -17.981 10
+      vertex 15.551 -17.981 0
+    endloop
+  endfacet
+  facet normal 0.729861 0.683596 0
+    outer loop
+      vertex 15.7648 -18.2596 10
+      vertex 15.6442 -18.1308 0
+      vertex 15.6442 -18.1308 10
+    endloop
+  endfacet
+  facet normal 0.729861 0.683596 0
+    outer loop
+      vertex 15.6442 -18.1308 0
+      vertex 15.7648 -18.2596 10
+      vertex 15.7648 -18.2596 0
+    endloop
+  endfacet
+  facet normal -0.634394 0.773009 0
+    outer loop
+      vertex 18.6676 -18.6676 0
+      vertex 18.5312 -18.7795 10
+      vertex 18.6676 -18.6676 10
+    endloop
+  endfacet
+  facet normal -0.634394 0.773009 0
+    outer loop
+      vertex 18.5312 -18.7795 10
+      vertex 18.6676 -18.6676 0
+      vertex 18.5312 -18.7795 0
+    endloop
+  endfacet
+  facet normal -0.0980104 0.995185 0
+    outer loop
+      vertex 18.2068 -18.9139 0
+      vertex 18.0312 -18.9312 10
+      vertex 18.2068 -18.9139 10
+    endloop
+  endfacet
+  facet normal -0.0980104 0.995185 0
+    outer loop
+      vertex 18.0312 -18.9312 10
+      vertex 18.2068 -18.9139 0
+      vertex 18.0312 -18.9312 0
+    endloop
+  endfacet
+  facet normal -0.881923 0.471394 0
+    outer loop
+      vertex 18.7795 -18.5312 0
+      vertex 18.8627 -18.3756 10
+      vertex 18.8627 -18.3756 0
+    endloop
+  endfacet
+  facet normal -0.881923 0.471394 0
+    outer loop
+      vertex 18.8627 -18.3756 10
+      vertex 18.7795 -18.5312 0
+      vertex 18.7795 -18.5312 10
+    endloop
+  endfacet
+  facet normal -0.956938 0.290291 0
+    outer loop
+      vertex 18.8627 -18.3756 0
+      vertex 18.9139 -18.2068 10
+      vertex 18.9139 -18.2068 0
+    endloop
+  endfacet
+  facet normal -0.956938 0.290291 0
+    outer loop
+      vertex 18.9139 -18.2068 10
+      vertex 18.8627 -18.3756 0
+      vertex 18.8627 -18.3756 10
+    endloop
+  endfacet
+  facet normal -0.812845 -0.58248 0
+    outer loop
+      vertex 18.3624 -15.9082 0
+      vertex 18.2596 -15.7648 10
+      vertex 18.2596 -15.7648 0
+    endloop
+  endfacet
+  facet normal -0.812845 -0.58248 0
+    outer loop
+      vertex 18.2596 -15.7648 10
+      vertex 18.3624 -15.9082 0
+      vertex 18.3624 -15.9082 10
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980104 0
+    outer loop
+      vertex 18.9139 -18.2068 0
+      vertex 18.9312 -18.0312 10
+      vertex 18.9312 -18.0312 0
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980104 0
+    outer loop
+      vertex 18.9312 -18.0312 10
+      vertex 18.9139 -18.2068 0
+      vertex 18.9139 -18.2068 10
+    endloop
+  endfacet
+  facet normal -0.812845 0.58248 0
+    outer loop
+      vertex 18.2596 15.7648 0
+      vertex 18.3624 15.9082 10
+      vertex 18.3624 15.9082 0
+    endloop
+  endfacet
+  facet normal -0.812845 0.58248 0
+    outer loop
+      vertex 18.3624 15.9082 10
+      vertex 18.2596 15.7648 0
+      vertex 18.2596 15.7648 10
+    endloop
+  endfacet
+  facet normal -0.910865 0.412705 0
+    outer loop
+      vertex 18.3624 15.9082 0
+      vertex 18.4352 16.0689 10
+      vertex 18.4352 16.0689 0
+    endloop
+  endfacet
+  facet normal -0.910865 0.412705 0
+    outer loop
+      vertex 18.4352 16.0689 10
+      vertex 18.3624 15.9082 0
+      vertex 18.3624 15.9082 10
+    endloop
+  endfacet
+  facet normal 0.986643 -0.162896 0
+    outer loop
+      vertex 15.4601 17.6418 10
+      vertex 15.4889 17.8159 0
+      vertex 15.4889 17.8159 10
+    endloop
+  endfacet
+  facet normal 0.986643 -0.162896 0
+    outer loop
+      vertex 15.4889 17.8159 0
+      vertex 15.4601 17.6418 10
+      vertex 15.4601 17.6418 0
+    endloop
+  endfacet
+  facet normal -0.162896 0.986643 0
+    outer loop
+      vertex 17.8159 15.4889 0
+      vertex 17.6418 15.4601 10
+      vertex 17.8159 15.4889 10
+    endloop
+  endfacet
+  facet normal -0.162896 0.986643 0
+    outer loop
+      vertex 17.6418 15.4601 10
+      vertex 17.8159 15.4889 0
+      vertex 17.6418 15.4601 0
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980094 0
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 18.9312 18.0312 10
+      vertex 18.9312 18.0312 0
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980094 0
+    outer loop
+      vertex 18.9312 18.0312 10
+      vertex 18.9139 17.8556 0
+      vertex 18.9139 17.8556 10
+    endloop
+  endfacet
+  facet normal 0.812844 0.582482 0
+    outer loop
+      vertex 15.6815 16.9895 10
+      vertex 15.5788 17.1329 0
+      vertex 15.5788 17.1329 10
+    endloop
+  endfacet
+  facet normal 0.812844 0.582482 0
+    outer loop
+      vertex 15.5788 17.1329 0
+      vertex 15.6815 16.9895 10
+      vertex 15.6815 16.9895 0
+    endloop
+  endfacet
+  facet normal 0.0980094 -0.995185 0
+    outer loop
+      vertex 17.8556 18.9139 0
+      vertex 18.0312 18.9312 10
+      vertex 17.8556 18.9139 10
+    endloop
+  endfacet
+  facet normal 0.0980094 -0.995185 0
+    outer loop
+      vertex 18.0312 18.9312 10
+      vertex 17.8556 18.9139 0
+      vertex 18.0312 18.9312 0
+    endloop
+  endfacet
+  facet normal -0.965926 0.258819 0
+    outer loop
+      vertex 18.4352 16.0689 0
+      vertex 18.9139 17.8556 10
+      vertex 18.9139 17.8556 0
+    endloop
+  endfacet
+  facet normal -0.965926 0.258819 0
+    outer loop
+      vertex 18.9139 17.8556 10
+      vertex 18.4352 16.0689 0
+      vertex 18.4352 16.0689 10
+    endloop
+  endfacet
+  facet normal 0.258819 -0.965926 0
+    outer loop
+      vertex 16.0689 18.4352 0
+      vertex 17.8556 18.9139 10
+      vertex 16.0689 18.4352 10
+    endloop
+  endfacet
+  facet normal 0.258819 -0.965926 0
+    outer loop
+      vertex 17.8556 18.9139 10
+      vertex 16.0689 18.4352 0
+      vertex 17.8556 18.9139 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 16.9895 15.6815 10
+      vertex 15.6815 16.9895 0
+      vertex 15.6815 16.9895 10
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 15.6815 16.9895 0
+      vertex 16.9895 15.6815 10
+      vertex 16.9895 15.6815 0
+    endloop
+  endfacet
+  facet normal 0.910863 0.412708 0
+    outer loop
+      vertex 15.5788 17.1329 10
+      vertex 15.506 17.2936 0
+      vertex 15.506 17.2936 10
+    endloop
+  endfacet
+  facet normal 0.910863 0.412708 0
+    outer loop
+      vertex 15.506 17.2936 0
+      vertex 15.5788 17.1329 10
+      vertex 15.5788 17.1329 0
+    endloop
+  endfacet
+  facet normal 0.227075 0.973877 -0
+    outer loop
+      vertex 17.4655 15.4659 0
+      vertex 17.2936 15.506 10
+      vertex 17.4655 15.4659 10
+    endloop
+  endfacet
+  facet normal 0.227075 0.973877 0
+    outer loop
+      vertex 17.2936 15.506 10
+      vertex 17.4655 15.4659 0
+      vertex 17.2936 15.506 0
+    endloop
+  endfacet
+  facet normal 0.582482 0.812844 -0
+    outer loop
+      vertex 17.1329 15.5788 0
+      vertex 16.9895 15.6815 10
+      vertex 17.1329 15.5788 10
+    endloop
+  endfacet
+  facet normal 0.582482 0.812844 0
+    outer loop
+      vertex 16.9895 15.6815 10
+      vertex 17.1329 15.5788 0
+      vertex 16.9895 15.6815 0
+    endloop
+  endfacet
+  facet normal -0.528066 0.849204 0
+    outer loop
+      vertex 18.1308 15.6442 0
+      vertex 17.981 15.551 10
+      vertex 18.1308 15.6442 10
+    endloop
+  endfacet
+  facet normal -0.528066 0.849204 0
+    outer loop
+      vertex 17.981 15.551 10
+      vertex 18.1308 15.6442 0
+      vertex 17.981 15.551 0
+    endloop
+  endfacet
+  facet normal -0.683596 0.729861 0
+    outer loop
+      vertex 18.2596 15.7648 0
+      vertex 18.1308 15.6442 10
+      vertex 18.2596 15.7648 10
+    endloop
+  endfacet
+  facet normal -0.683596 0.729861 0
+    outer loop
+      vertex 18.1308 15.6442 10
+      vertex 18.2596 15.7648 0
+      vertex 18.1308 15.6442 0
+    endloop
+  endfacet
+  facet normal 0.729861 -0.683596 0
+    outer loop
+      vertex 15.6442 18.1308 10
+      vertex 15.7648 18.2596 0
+      vertex 15.7648 18.2596 10
+    endloop
+  endfacet
+  facet normal 0.729861 -0.683596 0
+    outer loop
+      vertex 15.7648 18.2596 0
+      vertex 15.6442 18.1308 10
+      vertex 15.6442 18.1308 0
+    endloop
+  endfacet
+  facet normal 0.58248 -0.812845 0
+    outer loop
+      vertex 15.7648 18.2596 0
+      vertex 15.9082 18.3624 10
+      vertex 15.7648 18.2596 10
+    endloop
+  endfacet
+  facet normal 0.58248 -0.812845 0
+    outer loop
+      vertex 15.9082 18.3624 10
+      vertex 15.7648 18.2596 0
+      vertex 15.9082 18.3624 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980104 0
+    outer loop
+      vertex 18.9312 18.0312 0
+      vertex 18.9139 18.2068 10
+      vertex 18.9139 18.2068 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980104 0
+    outer loop
+      vertex 18.9139 18.2068 10
+      vertex 18.9312 18.0312 0
+      vertex 18.9312 18.0312 10
+    endloop
+  endfacet
+  facet normal -0.773009 -0.634394 0
+    outer loop
+      vertex 18.7795 18.5312 0
+      vertex 18.6676 18.6676 10
+      vertex 18.6676 18.6676 0
+    endloop
+  endfacet
+  facet normal -0.773009 -0.634394 0
+    outer loop
+      vertex 18.6676 18.6676 10
+      vertex 18.7795 18.5312 0
+      vertex 18.7795 18.5312 10
+    endloop
+  endfacet
+  facet normal -0.881923 -0.471394 0
+    outer loop
+      vertex 18.8627 18.3756 0
+      vertex 18.7795 18.5312 10
+      vertex 18.7795 18.5312 0
+    endloop
+  endfacet
+  facet normal -0.881923 -0.471394 0
+    outer loop
+      vertex 18.7795 18.5312 10
+      vertex 18.8627 18.3756 0
+      vertex 18.8627 18.3756 10
+    endloop
+  endfacet
+  facet normal -0.471394 -0.881923 0
+    outer loop
+      vertex 18.3756 18.8627 0
+      vertex 18.5312 18.7795 10
+      vertex 18.3756 18.8627 10
+    endloop
+  endfacet
+  facet normal -0.471394 -0.881923 -0
+    outer loop
+      vertex 18.5312 18.7795 10
+      vertex 18.3756 18.8627 0
+      vertex 18.5312 18.7795 0
+    endloop
+  endfacet
+  facet normal -0.0980104 -0.995185 0
+    outer loop
+      vertex 18.0312 18.9312 0
+      vertex 18.2068 18.9139 10
+      vertex 18.0312 18.9312 10
+    endloop
+  endfacet
+  facet normal -0.0980104 -0.995185 -0
+    outer loop
+      vertex 18.2068 18.9139 10
+      vertex 18.0312 18.9312 0
+      vertex 18.2068 18.9139 0
+    endloop
+  endfacet
+  facet normal 0.849204 -0.528066 0
+    outer loop
+      vertex 15.551 17.981 10
+      vertex 15.6442 18.1308 0
+      vertex 15.6442 18.1308 10
+    endloop
+  endfacet
+  facet normal 0.849204 -0.528066 0
+    outer loop
+      vertex 15.6442 18.1308 0
+      vertex 15.551 17.981 10
+      vertex 15.551 17.981 0
+    endloop
+  endfacet
+  facet normal 0.935906 -0.352251 0
+    outer loop
+      vertex 15.4889 17.8159 10
+      vertex 15.551 17.981 0
+      vertex 15.551 17.981 10
+    endloop
+  endfacet
+  facet normal 0.935906 -0.352251 0
+    outer loop
+      vertex 15.551 17.981 0
+      vertex 15.4889 17.8159 10
+      vertex 15.4889 17.8159 0
+    endloop
+  endfacet
+  facet normal 0.999465 0.0327187 0
+    outer loop
+      vertex 15.4659 17.4655 10
+      vertex 15.4601 17.6418 0
+      vertex 15.4601 17.6418 10
+    endloop
+  endfacet
+  facet normal 0.999465 0.0327187 0
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 15.4659 17.4655 10
+      vertex 15.4659 17.4655 0
+    endloop
+  endfacet
+  facet normal 0.973877 0.227075 0
+    outer loop
+      vertex 15.506 17.2936 10
+      vertex 15.4659 17.4655 0
+      vertex 15.4659 17.4655 10
+    endloop
+  endfacet
+  facet normal 0.973877 0.227075 0
+    outer loop
+      vertex 15.4659 17.4655 0
+      vertex 15.506 17.2936 10
+      vertex 15.506 17.2936 0
+    endloop
+  endfacet
+  facet normal 0.412708 0.910863 -0
+    outer loop
+      vertex 17.2936 15.506 0
+      vertex 17.1329 15.5788 10
+      vertex 17.2936 15.506 10
+    endloop
+  endfacet
+  facet normal 0.412708 0.910863 0
+    outer loop
+      vertex 17.1329 15.5788 10
+      vertex 17.2936 15.506 0
+      vertex 17.1329 15.5788 0
+    endloop
+  endfacet
+  facet normal 0.0327187 0.999465 -0
+    outer loop
+      vertex 17.6418 15.4601 0
+      vertex 17.4655 15.4659 10
+      vertex 17.6418 15.4601 10
+    endloop
+  endfacet
+  facet normal 0.0327187 0.999465 0
+    outer loop
+      vertex 17.4655 15.4659 10
+      vertex 17.6418 15.4601 0
+      vertex 17.4655 15.4659 0
+    endloop
+  endfacet
+  facet normal -0.352251 0.935906 0
+    outer loop
+      vertex 17.981 15.551 0
+      vertex 17.8159 15.4889 10
+      vertex 17.981 15.551 10
+    endloop
+  endfacet
+  facet normal -0.352251 0.935906 0
+    outer loop
+      vertex 17.8159 15.4889 10
+      vertex 17.981 15.551 0
+      vertex 17.8159 15.4889 0
+    endloop
+  endfacet
+  facet normal -0.956938 -0.290291 0
+    outer loop
+      vertex 18.9139 18.2068 0
+      vertex 18.8627 18.3756 10
+      vertex 18.8627 18.3756 0
+    endloop
+  endfacet
+  facet normal -0.956938 -0.290291 0
+    outer loop
+      vertex 18.8627 18.3756 10
+      vertex 18.9139 18.2068 0
+      vertex 18.9139 18.2068 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.773009 0
+    outer loop
+      vertex 18.5312 18.7795 0
+      vertex 18.6676 18.6676 10
+      vertex 18.5312 18.7795 10
+    endloop
+  endfacet
+  facet normal -0.634394 -0.773009 -0
+    outer loop
+      vertex 18.6676 18.6676 10
+      vertex 18.5312 18.7795 0
+      vertex 18.6676 18.6676 0
+    endloop
+  endfacet
+  facet normal -0.290291 -0.956938 0
+    outer loop
+      vertex 18.2068 18.9139 0
+      vertex 18.3756 18.8627 10
+      vertex 18.2068 18.9139 10
+    endloop
+  endfacet
+  facet normal -0.290291 -0.956938 -0
+    outer loop
+      vertex 18.3756 18.8627 10
+      vertex 18.2068 18.9139 0
+      vertex 18.3756 18.8627 0
+    endloop
+  endfacet
+  facet normal 0.412705 -0.910865 0
+    outer loop
+      vertex 15.9082 18.3624 0
+      vertex 16.0689 18.4352 10
+      vertex 15.9082 18.3624 10
+    endloop
+  endfacet
+  facet normal 0.412705 -0.910865 0
+    outer loop
+      vertex 16.0689 18.4352 10
+      vertex 15.9082 18.3624 0
+      vertex 16.0689 18.4352 0
     endloop
   endfacet
   facet normal 1 -0 0
@@ -15693,6 +12613,3156 @@ solid OpenSCAD_Model
       vertex 25.4558 -14.8492 0
     endloop
   endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 15.0815 10
+      vertex -17.8159 15.4889 10
+      vertex -17.981 15.551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8159 15.4889 10
+      vertex -18.0359 13.7838 10
+      vertex -17.9668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 15.0815 10
+      vertex -17.981 15.551 10
+      vertex -18.1308 15.6442 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8159 15.4889 10
+      vertex -18.2408 14.4591 10
+      vertex -18.0359 13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5735 15.0815 10
+      vertex -18.1308 15.6442 10
+      vertex -18.2596 15.7648 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 15.6271 10
+      vertex -18.2596 15.7648 10
+      vertex -18.3624 15.9082 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0212 15.6271 10
+      vertex -18.3624 15.9082 10
+      vertex -18.4352 16.0689 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8159 15.4889 10
+      vertex -18.5735 15.0815 10
+      vertex -18.2408 14.4591 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5667 16.0748 10
+      vertex -18.4352 16.0689 10
+      vertex -18.9139 17.8556 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2596 15.7648 10
+      vertex -19.0212 15.6271 10
+      vertex -18.5735 15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8644 16.6123 10
+      vertex -18.9139 17.8556 10
+      vertex -18.9312 18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4655 -15.4659 10
+      vertex -18.2408 -14.4591 10
+      vertex -17.6418 -15.4601 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6418 -15.4601 10
+      vertex -18.2408 -14.4591 10
+      vertex -17.8159 -15.4889 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.5735 -15.0815 10
+      vertex -17.8159 -15.4889 10
+      vertex -18.2408 -14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8159 -15.4889 10
+      vertex -18.5735 -15.0815 10
+      vertex -17.981 -15.551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.981 -15.551 10
+      vertex -18.5735 -15.0815 10
+      vertex -18.1308 -15.6442 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.1308 -15.6442 10
+      vertex -18.5735 -15.0815 10
+      vertex -18.2596 -15.7648 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.0212 -15.6271 10
+      vertex -18.2596 -15.7648 10
+      vertex -18.5735 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2596 -15.7648 10
+      vertex -19.0212 -15.6271 10
+      vertex -18.3624 -15.9082 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3624 -15.9082 10
+      vertex -19.0212 -15.6271 10
+      vertex -18.4352 -16.0689 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4352 -16.0689 10
+      vertex -19.5667 -16.0748 10
+      vertex -18.9139 -17.8556 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 -16.0748 10
+      vertex -18.4352 -16.0689 10
+      vertex -19.0212 -15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 18.2408 10
+      vertex -15.4889 17.8159 10
+      vertex -15.4601 17.6418 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 18.5735 10
+      vertex -15.551 17.981 10
+      vertex -15.4889 17.8159 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.7648 18.2596 10
+      vertex -15.0815 18.5735 10
+      vertex -15.6271 19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 18.5735 10
+      vertex -15.6442 18.1308 10
+      vertex -15.551 17.981 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 18.5735 10
+      vertex -15.7648 18.2596 10
+      vertex -15.6442 18.1308 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6271 19.0212 10
+      vertex -15.9082 18.3624 10
+      vertex -15.7648 18.2596 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6271 19.0212 10
+      vertex -16.0689 18.4352 10
+      vertex -15.9082 18.3624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 19.5667 10
+      vertex -16.0689 18.4352 10
+      vertex -15.6271 19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8556 18.9139 10
+      vertex -16.0748 19.5667 10
+      vertex -16.4074 20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8556 18.9139 10
+      vertex -16.4074 20.1891 10
+      vertex -16.6123 20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 19.5667 10
+      vertex -17.8556 18.9139 10
+      vertex -16.0689 18.4352 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2068 18.9139 10
+      vertex -16.6123 20.8644 10
+      vertex -16.6815 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 -19.3185 10
+      vertex -9.55065 -20.8644 10
+      vertex -9.48148 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 -19.3185 10
+      vertex -9.75551 -20.1891 10
+      vertex -9.55065 -20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.0882 -19.5667 10
+      vertex -5.17638 -19.3185 10
+      vertex -10 -17.3205 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 -19.3185 10
+      vertex -10.0882 -19.5667 10
+      vertex -9.75551 -20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -17.3205 10
+      vertex -10.5359 -19.0212 10
+      vertex -10.0882 -19.5667 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -17.3205 10
+      vertex -11.0814 -18.5735 10
+      vertex -10.5359 -19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -17.3205 10
+      vertex -11.7038 -18.2408 10
+      vertex -11.0814 -18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -17.3205 10
+      vertex -12.3792 -18.0359 10
+      vertex -11.7038 -18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -12.3792 -18.0359 10
+      vertex -10 -17.3205 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 -18.0359 10
+      vertex -14.1421 -14.1421 10
+      vertex -13.0815 -17.9668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0815 -17.9668 10
+      vertex -14.1421 -14.1421 10
+      vertex -13.7838 -18.0359 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.5788 -17.1329 10
+      vertex -13.7838 -18.0359 10
+      vertex -14.1421 -14.1421 10
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -15.506 -17.2936 10
+      vertex -13.7838 -18.0359 10
+      vertex -15.5788 -17.1329 10
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -15.4601 -17.6418 10
+      vertex -14.4591 -18.2408 10
+      vertex -15.4659 -17.4655 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.4889 -17.8159 10
+      vertex -14.4591 -18.2408 10
+      vertex -15.4601 -17.6418 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 -18.0359 10
+      vertex -15.4659 -17.4655 10
+      vertex -14.4591 -18.2408 10
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -15.4659 -17.4655 10
+      vertex -13.7838 -18.0359 10
+      vertex -15.506 -17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -15.6815 -16.9895 10
+      vertex -15.5788 -17.1329 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -16.9895 -15.6815 10
+      vertex -15.6815 -16.9895 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -17.1329 -15.5788 10
+      vertex -16.9895 -15.6815 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.0359 -13.7838 10
+      vertex -14.1421 -14.1421 10
+      vertex -17.9668 -13.0815 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.0359 -12.3792 10
+      vertex -14.1421 -14.1421 10
+      vertex -17.3205 -10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -18.0359 -13.7838 10
+      vertex -17.1329 -15.5788 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.1329 -15.5788 10
+      vertex -18.0359 -13.7838 10
+      vertex -17.2936 -15.506 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2936 -15.506 10
+      vertex -18.0359 -13.7838 10
+      vertex -17.4655 -15.4659 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2408 -14.4591 10
+      vertex -17.4655 -15.4659 10
+      vertex -18.0359 -13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -18.0359 -12.3792 10
+      vertex -17.9668 -13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3205 -10 10
+      vertex -18.2408 -11.7038 10
+      vertex -18.0359 -12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3205 -10 10
+      vertex -18.5735 -11.0814 10
+      vertex -18.2408 -11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3205 -10 10
+      vertex -19.0212 -10.5359 10
+      vertex -18.5735 -11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.5667 -10.0882 10
+      vertex -17.3205 -10 10
+      vertex -19.3185 -5.17638 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3205 -10 10
+      vertex -19.5667 -10.0882 10
+      vertex -19.0212 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9444 -9.75551 10
+      vertex -19.3185 -5.17638 10
+      vertex -20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -20.1891 -9.75551 10
+      vertex -19.5667 -10.0882 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5668 9.48148 10
+      vertex -19.3185 5.17638 10
+      vertex -20.8644 9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 9.55065 10
+      vertex -19.3185 5.17638 10
+      vertex -21.5668 9.48148 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -20.8644 -9.55065 10
+      vertex -20.1891 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9444 9.75551 10
+      vertex -19.3185 5.17638 10
+      vertex -22.2691 9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -21.5668 -9.48148 10
+      vertex -20.8644 -9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 5.17638 10
+      vertex -22.9444 9.75551 10
+      vertex -20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -22.2691 -9.55065 10
+      vertex -21.5668 -9.48148 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 10.0882 10
+      vertex -20 0 10
+      vertex -22.9444 9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -22.9444 -9.75551 10
+      vertex -22.2691 -9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1123 10.5359 10
+      vertex -20 0 10
+      vertex -23.5668 10.0882 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20 0 10
+      vertex -23.5668 -10.0882 10
+      vertex -22.9444 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1123 -10.5359 10
+      vertex -20 0 10
+      vertex -24.1123 10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20 0 10
+      vertex -24.1123 -10.5359 10
+      vertex -23.5668 -10.0882 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.56 11.0814 10
+      vertex -24.1123 -10.5359 10
+      vertex -24.1123 10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.56 11.0814 10
+      vertex -24.56 -11.0814 10
+      vertex -24.1123 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 11.7038 10
+      vertex -24.56 -11.0814 10
+      vertex -24.56 11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 11.7038 10
+      vertex -24.8927 -11.7038 10
+      vertex -24.56 -11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 12.3792 10
+      vertex -24.8927 -11.7038 10
+      vertex -24.8927 11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 12.3792 10
+      vertex -25.0976 -12.3792 10
+      vertex -24.8927 -11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.4558 14.8492 10
+      vertex -25.0976 12.3792 10
+      vertex -25.1668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 12.3792 10
+      vertex -25.4558 14.8492 10
+      vertex -25.0976 -12.3792 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.55065 20.8644 10
+      vertex -5.17638 19.3185 10
+      vertex -9.48148 21.5668 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.75551 20.1891 10
+      vertex -5.17638 19.3185 10
+      vertex -9.55065 20.8644 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.0882 19.5667 10
+      vertex -5.17638 19.3185 10
+      vertex -9.75551 20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 19.3185 10
+      vertex -10.0882 19.5667 10
+      vertex -10 17.3205 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.5359 19.0212 10
+      vertex -10 17.3205 10
+      vertex -10.0882 19.5667 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.0814 18.5735 10
+      vertex -10 17.3205 10
+      vertex -10.5359 19.0212 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7038 18.2408 10
+      vertex -10 17.3205 10
+      vertex -11.0814 18.5735 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3792 18.0359 10
+      vertex -10 17.3205 10
+      vertex -11.7038 18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 14.1421 10
+      vertex -12.3792 18.0359 10
+      vertex -13.0815 17.9668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 14.1421 10
+      vertex -13.0815 17.9668 10
+      vertex -13.7838 18.0359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 18.0359 10
+      vertex -14.1421 14.1421 10
+      vertex -10 17.3205 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4659 17.4655 10
+      vertex -13.7838 18.0359 10
+      vertex -14.4591 18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4889 17.8159 10
+      vertex -14.4591 18.2408 10
+      vertex -15.0815 18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 18.2408 10
+      vertex -15.4601 17.6418 10
+      vertex -15.4659 17.4655 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 18.0359 10
+      vertex -15.4659 17.4655 10
+      vertex -15.506 17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 18.0359 10
+      vertex -15.506 17.2936 10
+      vertex -15.5788 17.1329 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 18.0359 10
+      vertex -15.5788 17.1329 10
+      vertex -14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6815 16.9895 10
+      vertex -14.1421 14.1421 10
+      vertex -15.5788 17.1329 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.9895 15.6815 10
+      vertex -14.1421 14.1421 10
+      vertex -15.6815 16.9895 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.1329 15.5788 10
+      vertex -14.1421 14.1421 10
+      vertex -16.9895 15.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 13.0815 10
+      vertex -17.1329 15.5788 10
+      vertex -17.2936 15.506 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.1329 15.5788 10
+      vertex -17.9668 13.0815 10
+      vertex -14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 13.0815 10
+      vertex -17.2936 15.506 10
+      vertex -17.4655 15.4659 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 13.0815 10
+      vertex -17.4655 15.4659 10
+      vertex -17.6418 15.4601 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9668 13.0815 10
+      vertex -17.6418 15.4601 10
+      vertex -17.8159 15.4889 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0359 12.3792 10
+      vertex -14.1421 14.1421 10
+      vertex -17.9668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1421 14.1421 10
+      vertex -18.0359 12.3792 10
+      vertex -17.3205 10 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2408 11.7038 10
+      vertex -17.3205 10 10
+      vertex -18.0359 12.3792 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.5735 11.0814 10
+      vertex -17.3205 10 10
+      vertex -18.2408 11.7038 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.0212 10.5359 10
+      vertex -17.3205 10 10
+      vertex -18.5735 11.0814 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5667 10.0882 10
+      vertex -17.3205 10 10
+      vertex -19.0212 10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3205 10 10
+      vertex -19.5667 10.0882 10
+      vertex -19.3185 5.17638 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.1891 9.75551 10
+      vertex -19.3185 5.17638 10
+      vertex -19.5667 10.0882 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8644 9.55065 10
+      vertex -19.3185 5.17638 10
+      vertex -20.1891 9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 -18.2408 10
+      vertex -15.4889 -17.8159 10
+      vertex -15.0815 -18.5735 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.551 -17.981 10
+      vertex -15.0815 -18.5735 10
+      vertex -15.4889 -17.8159 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6442 -18.1308 10
+      vertex -15.0815 -18.5735 10
+      vertex -15.551 -17.981 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.7648 -18.2596 10
+      vertex -15.0815 -18.5735 10
+      vertex -15.6442 -18.1308 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 -18.5735 10
+      vertex -15.7648 -18.2596 10
+      vertex -15.6271 -19.0212 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.9082 -18.3624 10
+      vertex -15.6271 -19.0212 10
+      vertex -15.7648 -18.2596 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.0689 -18.4352 10
+      vertex -15.6271 -19.0212 10
+      vertex -15.9082 -18.3624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0689 -18.4352 10
+      vertex -16.0748 -19.5667 10
+      vertex -15.6271 -19.0212 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.8556 -18.9139 10
+      vertex -16.0748 -19.5667 10
+      vertex -16.0689 -18.4352 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 -19.5667 10
+      vertex -17.8556 -18.9139 10
+      vertex -16.4074 -20.1891 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.0312 -18.9312 10
+      vertex -16.6123 -20.8644 10
+      vertex -17.8556 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4074 -20.1891 10
+      vertex -17.8556 -18.9139 10
+      vertex -16.6123 -20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2068 -18.9139 10
+      vertex 16.6123 -20.8644 10
+      vertex 16.6815 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8556 -18.9139 10
+      vertex 16.4074 -20.1891 10
+      vertex 16.6123 -20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8556 -18.9139 10
+      vertex 16.0748 -19.5667 10
+      vertex 16.4074 -20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0689 -18.4352 10
+      vertex 16.0748 -19.5667 10
+      vertex 17.8556 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 -19.0212 10
+      vertex 16.0689 -18.4352 10
+      vertex 15.9082 -18.3624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6271 -19.0212 10
+      vertex 15.9082 -18.3624 10
+      vertex 15.7648 -18.2596 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 -18.5735 10
+      vertex 15.7648 -18.2596 10
+      vertex 15.6442 -18.1308 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0689 -18.4352 10
+      vertex 15.6271 -19.0212 10
+      vertex 16.0748 -19.5667 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 -18.5735 10
+      vertex 15.6442 -18.1308 10
+      vertex 15.551 -17.981 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.0815 -18.5735 10
+      vertex 15.551 -17.981 10
+      vertex 15.4889 -17.8159 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 -18.2408 10
+      vertex 15.4889 -17.8159 10
+      vertex 15.4601 -17.6418 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.7648 -18.2596 10
+      vertex 15.0815 -18.5735 10
+      vertex 15.6271 -19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0312 18.9312 10
+      vertex 16.6123 20.8644 10
+      vertex 17.8556 18.9139 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.4074 20.1891 10
+      vertex 17.8556 18.9139 10
+      vertex 16.6123 20.8644 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.0748 19.5667 10
+      vertex 17.8556 18.9139 10
+      vertex 16.4074 20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 19.5667 10
+      vertex 16.0689 18.4352 10
+      vertex 17.8556 18.9139 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.6271 19.0212 10
+      vertex 16.0689 18.4352 10
+      vertex 16.0748 19.5667 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0689 18.4352 10
+      vertex 15.6271 19.0212 10
+      vertex 15.9082 18.3624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9082 18.3624 10
+      vertex 15.6271 19.0212 10
+      vertex 15.7648 18.2596 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.0815 18.5735 10
+      vertex 15.7648 18.2596 10
+      vertex 15.6271 19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.7648 18.2596 10
+      vertex 15.0815 18.5735 10
+      vertex 15.6442 18.1308 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6442 18.1308 10
+      vertex 15.0815 18.5735 10
+      vertex 15.551 17.981 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.551 17.981 10
+      vertex 15.0815 18.5735 10
+      vertex 15.4889 17.8159 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.4591 18.2408 10
+      vertex 15.4889 17.8159 10
+      vertex 15.0815 18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 -16.6123 10
+      vertex 18.9139 -17.8556 10
+      vertex 18.9312 -18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2596 -15.7648 10
+      vertex 19.0212 -15.6271 10
+      vertex 18.5735 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 -16.0748 10
+      vertex 18.4352 -16.0689 10
+      vertex 18.9139 -17.8556 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 -15.6271 10
+      vertex 18.3624 -15.9082 10
+      vertex 18.4352 -16.0689 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 -15.6271 10
+      vertex 18.2596 -15.7648 10
+      vertex 18.3624 -15.9082 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8159 -15.4889 10
+      vertex 18.5735 -15.0815 10
+      vertex 18.2408 -14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 -15.0815 10
+      vertex 18.1308 -15.6442 10
+      vertex 18.2596 -15.7648 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4655 -15.4659 10
+      vertex 18.2408 -14.4591 10
+      vertex 18.0359 -13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 -15.0815 10
+      vertex 17.981 -15.551 10
+      vertex 18.1308 -15.6442 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 -14.1421 10
+      vertex 18.0359 -13.7838 10
+      vertex 17.9668 -13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 -15.0815 10
+      vertex 17.8159 -15.4889 10
+      vertex 17.981 -15.551 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.0976 -12.3792 10
+      vertex 25.4558 -14.8492 10
+      vertex 25.0976 12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 -14.8492 10
+      vertex 25.0976 -12.3792 10
+      vertex 25.1668 -13.0815 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8927 11.7038 10
+      vertex 25.0976 -12.3792 10
+      vertex 25.0976 12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8927 11.7038 10
+      vertex 24.8927 -11.7038 10
+      vertex 25.0976 -12.3792 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.56 11.0814 10
+      vertex 24.8927 -11.7038 10
+      vertex 24.8927 11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.56 11.0814 10
+      vertex 24.56 -11.0814 10
+      vertex 24.8927 -11.7038 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.1123 10.5359 10
+      vertex 24.56 -11.0814 10
+      vertex 24.56 11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 10.5359 10
+      vertex 24.1123 -10.5359 10
+      vertex 24.56 -11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20 0 10
+      vertex 24.1123 10.5359 10
+      vertex 23.5668 10.0882 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 10.5359 10
+      vertex 20 0 10
+      vertex 24.1123 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20 0 10
+      vertex 23.5668 10.0882 10
+      vertex 22.9444 9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 -10.5359 10
+      vertex 20 0 10
+      vertex 23.5668 -10.0882 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 22.9444 9.75551 10
+      vertex 22.2691 9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 -10.0882 10
+      vertex 20 0 10
+      vertex 22.9444 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 22.2691 9.55065 10
+      vertex 21.5668 9.48148 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.3185 -5.17638 10
+      vertex 22.9444 -9.75551 10
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 21.5668 9.48148 10
+      vertex 20.8644 9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 -9.75551 10
+      vertex 19.3185 -5.17638 10
+      vertex 22.2691 -9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 20.8644 9.55065 10
+      vertex 20.1891 9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2691 -9.55065 10
+      vertex 19.3185 -5.17638 10
+      vertex 21.5668 -9.48148 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 -9.48148 10
+      vertex 19.3185 -5.17638 10
+      vertex 20.8644 -9.55065 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 20.1891 9.75551 10
+      vertex 19.5667 10.0882 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 9.75551 10
+      vertex 19.3185 5.17638 10
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3205 10 10
+      vertex 19.5667 10.0882 10
+      vertex 19.0212 10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3205 10 10
+      vertex 19.0212 10.5359 10
+      vertex 18.5735 11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3205 10 10
+      vertex 18.5735 11.0814 10
+      vertex 18.2408 11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3205 10 10
+      vertex 18.2408 11.7038 10
+      vertex 18.0359 12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 14.4591 10
+      vertex 17.4655 15.4659 10
+      vertex 18.0359 13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2936 15.506 10
+      vertex 18.0359 13.7838 10
+      vertex 17.4655 15.4659 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.1329 15.5788 10
+      vertex 18.0359 13.7838 10
+      vertex 17.2936 15.506 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.1421 14.1421 10
+      vertex 18.0359 13.7838 10
+      vertex 17.1329 15.5788 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 10.0882 10
+      vertex 17.3205 10 10
+      vertex 19.3185 5.17638 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 13.7838 10
+      vertex 14.1421 14.1421 10
+      vertex 17.9668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9668 13.0815 10
+      vertex 14.1421 14.1421 10
+      vertex 18.0359 12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 14.1421 10
+      vertex 17.1329 15.5788 10
+      vertex 16.9895 15.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 14.1421 10
+      vertex 16.9895 15.6815 10
+      vertex 15.6815 16.9895 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 14.1421 10
+      vertex 15.6815 16.9895 10
+      vertex 15.5788 17.1329 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7838 18.0359 10
+      vertex 15.5788 17.1329 10
+      vertex 15.506 17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4889 17.8159 10
+      vertex 14.4591 18.2408 10
+      vertex 15.4601 17.6418 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4601 17.6418 10
+      vertex 14.4591 18.2408 10
+      vertex 15.4659 17.4655 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.7838 18.0359 10
+      vertex 15.4659 17.4655 10
+      vertex 14.4591 18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4659 17.4655 10
+      vertex 13.7838 18.0359 10
+      vertex 15.506 17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 12.3792 10
+      vertex 14.1421 14.1421 10
+      vertex 17.3205 10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5788 17.1329 10
+      vertex 13.7838 18.0359 10
+      vertex 14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0815 17.9668 10
+      vertex 14.1421 14.1421 10
+      vertex 13.7838 18.0359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 18.0359 10
+      vertex 14.1421 14.1421 10
+      vertex 13.0815 17.9668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 17.3205 10
+      vertex 12.3792 18.0359 10
+      vertex 11.7038 18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 17.3205 10
+      vertex 11.7038 18.2408 10
+      vertex 11.0814 18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 17.3205 10
+      vertex 11.0814 18.5735 10
+      vertex 10.5359 19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 17.3205 10
+      vertex 10.5359 19.0212 10
+      vertex 10.0882 19.5667 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 18.0359 10
+      vertex 10 17.3205 10
+      vertex 14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.17638 19.3185 10
+      vertex 10.0882 19.5667 10
+      vertex 9.75551 20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.17638 19.3185 10
+      vertex 9.75551 20.1891 10
+      vertex 9.55065 20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0882 19.5667 10
+      vertex 5.17638 19.3185 10
+      vertex 10 17.3205 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.17638 19.3185 10
+      vertex 9.55065 20.8644 10
+      vertex 9.48148 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.0976 12.3792 10
+      vertex 25.4558 14.8492 10
+      vertex 25.1668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 25.0976 13.7838 10
+      vertex 25.1668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 24.8927 14.4591 10
+      vertex 25.0976 13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 24.56 15.0815 10
+      vertex 24.8927 14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 24.1123 15.6271 10
+      vertex 24.56 15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 23.5668 16.0748 10
+      vertex 24.1123 15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1891 16.4074 10
+      vertex 18.9139 17.8556 10
+      vertex 19.5667 16.0748 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 16.6123 10
+      vertex 18.9139 17.8556 10
+      vertex 20.1891 16.4074 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9139 17.8556 10
+      vertex 20.8644 16.6123 10
+      vertex 18.9312 18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9139 18.2068 10
+      vertex 20.8644 16.6123 10
+      vertex 21.5668 16.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.7795 18.5312 10
+      vertex 21.5668 16.6815 10
+      vertex 22.2691 16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 22.2691 10
+      vertex 22.2691 16.6123 10
+      vertex 22.9444 16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 16.6123 10
+      vertex 18.9139 18.2068 10
+      vertex 18.9312 18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 16.6815 10
+      vertex 18.8627 18.3756 10
+      vertex 18.9139 18.2068 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5668 16.6815 10
+      vertex 18.7795 18.5312 10
+      vertex 18.8627 18.3756 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2691 16.6123 10
+      vertex 18.6676 18.6676 10
+      vertex 18.7795 18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2691 16.6123 10
+      vertex 16.6123 22.2691 10
+      vertex 18.6676 18.6676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 22.9444 10
+      vertex 22.9444 16.4074 10
+      vertex 23.5668 16.0748 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2068 18.9139 10
+      vertex 16.6123 20.8644 10
+      vertex 18.0312 18.9312 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.6123 20.8644 10
+      vertex 18.2068 18.9139 10
+      vertex 16.6815 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3756 18.8627 10
+      vertex 16.6815 21.5668 10
+      vertex 18.2068 18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5312 18.7795 10
+      vertex 16.6815 21.5668 10
+      vertex 18.3756 18.8627 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6676 18.6676 10
+      vertex 16.6123 22.2691 10
+      vertex 18.5312 18.7795 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 23.5668 10
+      vertex 23.5668 16.0748 10
+      vertex 25.4558 14.8492 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5312 18.7795 10
+      vertex 16.6123 22.2691 10
+      vertex 16.6815 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9444 16.4074 10
+      vertex 16.4074 22.9444 10
+      vertex 16.6123 22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 16.0748 10
+      vertex 16.0748 23.5668 10
+      vertex 16.4074 22.9444 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 16.0748 23.5668 10
+      vertex 25.4558 14.8492 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 23.5668 10
+      vertex 14.8492 25.4558 10
+      vertex 15.6271 24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 15.0815 24.56 10
+      vertex 15.6271 24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 14.4591 24.8927 10
+      vertex 15.0815 24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 13.7838 25.0976 10
+      vertex 14.4591 24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 13.0815 25.1668 10
+      vertex 13.7838 25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 25.4558 10
+      vertex 12.3792 25.0976 10
+      vertex 13.0815 25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.55065 22.2691 10
+      vertex 5.17638 19.3185 10
+      vertex 9.48148 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 22.9444 10
+      vertex 5.17638 19.3185 10
+      vertex 9.55065 22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 10
+      vertex 9.75551 22.9444 10
+      vertex 10.0882 23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 10
+      vertex 10.0882 23.5668 10
+      vertex 10.5359 24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 22.9444 10
+      vertex 0 20 10
+      vertex 5.17638 19.3185 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 24.1123 10
+      vertex 10.5359 24.1123 10
+      vertex 11.0814 24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 24.56 10
+      vertex 11.0814 24.56 10
+      vertex 11.7038 24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5359 24.1123 10
+      vertex -10.5359 24.1123 10
+      vertex 0 20 10
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -9.75551 22.9444 10
+      vertex 0 20 10
+      vertex -10.0882 23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 24.8927 10
+      vertex 11.7038 24.8927 10
+      vertex 12.3792 25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 19.3185 10
+      vertex -9.55065 22.2691 10
+      vertex -9.48148 21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 25.0976 10
+      vertex 12.3792 25.0976 10
+      vertex 14.8492 25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.17638 19.3185 10
+      vertex -9.75551 22.9444 10
+      vertex -9.55065 22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 10
+      vertex -9.75551 22.9444 10
+      vertex -5.17638 19.3185 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 10
+      vertex -10.5359 24.1123 10
+      vertex -10.0882 23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0814 24.56 10
+      vertex -11.0814 24.56 10
+      vertex -10.5359 24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7038 24.8927 10
+      vertex -11.7038 24.8927 10
+      vertex -11.0814 24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 25.0976 10
+      vertex -12.3792 25.0976 10
+      vertex -11.7038 24.8927 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -12.3792 25.0976 10
+      vertex 14.8492 25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 25.0976 10
+      vertex -14.8492 25.4558 10
+      vertex -13.0815 25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -13.7838 25.0976 10
+      vertex -13.0815 25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -14.4591 24.8927 10
+      vertex -13.7838 25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -15.0815 24.56 10
+      vertex -14.4591 24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -15.6271 24.1123 10
+      vertex -15.0815 24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -16.0748 23.5668 10
+      vertex -15.6271 24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5312 18.7795 10
+      vertex -16.6815 21.5668 10
+      vertex -16.6123 22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 16.6123 10
+      vertex -16.6123 22.2691 10
+      vertex -16.4074 22.9444 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 20.8644 10
+      vertex -18.0312 18.9312 10
+      vertex -17.8556 18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 20.8644 10
+      vertex -18.2068 18.9139 10
+      vertex -18.0312 18.9312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6815 21.5668 10
+      vertex -18.3756 18.8627 10
+      vertex -18.2068 18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6815 21.5668 10
+      vertex -18.5312 18.7795 10
+      vertex -18.3756 18.8627 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 22.2691 10
+      vertex -18.6676 18.6676 10
+      vertex -18.5312 18.7795 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 22.2691 10
+      vertex -22.2691 16.6123 10
+      vertex -18.6676 18.6676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9444 16.4074 10
+      vertex -16.4074 22.9444 10
+      vertex -16.0748 23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4352 16.0689 10
+      vertex -19.5667 16.0748 10
+      vertex -19.0212 15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8644 16.6123 10
+      vertex -18.9312 18.0312 10
+      vertex -18.9139 18.2068 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 16.6815 10
+      vertex -18.9139 18.2068 10
+      vertex -18.8627 18.3756 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9139 17.8556 10
+      vertex -20.1891 16.4074 10
+      vertex -19.5667 16.0748 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5668 16.6815 10
+      vertex -18.8627 18.3756 10
+      vertex -18.7795 18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6676 18.6676 10
+      vertex -22.2691 16.6123 10
+      vertex -18.7795 18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9139 17.8556 10
+      vertex -20.8644 16.6123 10
+      vertex -20.1891 16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 16.0748 10
+      vertex -16.0748 23.5668 10
+      vertex -14.8492 25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9139 18.2068 10
+      vertex -21.5668 16.6815 10
+      vertex -20.8644 16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.7795 18.5312 10
+      vertex -22.2691 16.6123 10
+      vertex -21.5668 16.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4074 22.9444 10
+      vertex -22.9444 16.4074 10
+      vertex -22.2691 16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 23.5668 10
+      vertex -23.5668 16.0748 10
+      vertex -22.9444 16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.4558 14.8492 10
+      vertex -23.5668 16.0748 10
+      vertex -14.8492 25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.4558 -14.8492 10
+      vertex -25.0976 -12.3792 10
+      vertex -25.4558 14.8492 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 13.7838 10
+      vertex -25.4558 14.8492 10
+      vertex -25.1668 13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 14.4591 10
+      vertex -25.4558 14.8492 10
+      vertex -25.0976 13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.56 15.0815 10
+      vertex -25.4558 14.8492 10
+      vertex -24.8927 14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1123 15.6271 10
+      vertex -25.4558 14.8492 10
+      vertex -24.56 15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 16.0748 10
+      vertex -25.4558 14.8492 10
+      vertex -24.1123 15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 25.0976 12.3792 10
+      vertex 25.4558 -14.8492 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.0976 -13.7838 10
+      vertex 25.4558 -14.8492 10
+      vertex 25.1668 -13.0815 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8927 -14.4591 10
+      vertex 25.4558 -14.8492 10
+      vertex 25.0976 -13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.56 -15.0815 10
+      vertex 25.4558 -14.8492 10
+      vertex 24.8927 -14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1123 -15.6271 10
+      vertex 25.4558 -14.8492 10
+      vertex 24.56 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5668 -16.0748 10
+      vertex 25.4558 -14.8492 10
+      vertex 24.1123 -15.6271 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4352 -16.0689 10
+      vertex 19.5667 -16.0748 10
+      vertex 19.0212 -15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9139 -17.8556 10
+      vertex 20.1891 -16.4074 10
+      vertex 19.5667 -16.0748 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9139 -17.8556 10
+      vertex 20.8644 -16.6123 10
+      vertex 20.1891 -16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9139 -18.2068 10
+      vertex 20.8644 -16.6123 10
+      vertex 18.9312 -18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 -16.6123 10
+      vertex 18.9139 -18.2068 10
+      vertex 21.5668 -16.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8627 -18.3756 10
+      vertex 21.5668 -16.6815 10
+      vertex 18.9139 -18.2068 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.7795 -18.5312 10
+      vertex 21.5668 -16.6815 10
+      vertex 18.8627 -18.3756 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.5668 -16.6815 10
+      vertex 18.7795 -18.5312 10
+      vertex 22.2691 -16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6676 -18.6676 10
+      vertex 22.2691 -16.6123 10
+      vertex 18.7795 -18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -22.2691 10
+      vertex 22.2691 -16.6123 10
+      vertex 18.6676 -18.6676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -22.2691 10
+      vertex 18.6676 -18.6676 10
+      vertex 18.5312 -18.7795 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.2691 -16.6123 10
+      vertex 16.6123 -22.2691 10
+      vertex 22.9444 -16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -20.8644 10
+      vertex 18.0312 -18.9312 10
+      vertex 17.8556 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -20.8644 10
+      vertex 18.2068 -18.9139 10
+      vertex 18.0312 -18.9312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6815 -21.5668 10
+      vertex 18.3756 -18.8627 10
+      vertex 18.2068 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6815 -21.5668 10
+      vertex 18.5312 -18.7795 10
+      vertex 18.3756 -18.8627 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6123 -22.2691 10
+      vertex 18.5312 -18.7795 10
+      vertex 16.6815 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4074 -22.9444 10
+      vertex 22.9444 -16.4074 10
+      vertex 16.6123 -22.2691 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.9444 -16.4074 10
+      vertex 16.4074 -22.9444 10
+      vertex 23.5668 -16.0748 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0748 -23.5668 10
+      vertex 23.5668 -16.0748 10
+      vertex 16.4074 -22.9444 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.5668 -16.0748 10
+      vertex 16.0748 -23.5668 10
+      vertex 25.4558 -14.8492 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8492 -25.4558 10
+      vertex 16.0748 -23.5668 10
+      vertex 15.6271 -24.1123 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.0748 -23.5668 10
+      vertex 14.8492 -25.4558 10
+      vertex 25.4558 -14.8492 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.0815 -24.56 10
+      vertex 14.8492 -25.4558 10
+      vertex 15.6271 -24.1123 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.4591 -24.8927 10
+      vertex 14.8492 -25.4558 10
+      vertex 15.0815 -24.56 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.7838 -25.0976 10
+      vertex 14.8492 -25.4558 10
+      vertex 14.4591 -24.8927 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0815 -25.1668 10
+      vertex 14.8492 -25.4558 10
+      vertex 13.7838 -25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 -25.0976 10
+      vertex 14.8492 -25.4558 10
+      vertex 13.0815 -25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.17638 -19.3185 10
+      vertex 9.55065 -22.2691 10
+      vertex 9.48148 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.17638 -19.3185 10
+      vertex 9.75551 -22.9444 10
+      vertex 9.55065 -22.2691 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -20 10
+      vertex 9.75551 -22.9444 10
+      vertex 5.17638 -19.3185 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 -22.9444 10
+      vertex 0 -20 10
+      vertex 10.0882 -23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0882 -23.5668 10
+      vertex 0 -20 10
+      vertex 10.5359 -24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 -24.1123 10
+      vertex 10.5359 -24.1123 10
+      vertex 0 -20 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5359 -24.1123 10
+      vertex -10.5359 -24.1123 10
+      vertex 11.0814 -24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 -22.9444 10
+      vertex 0 -20 10
+      vertex -5.17638 -19.3185 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.55065 -22.2691 10
+      vertex -5.17638 -19.3185 10
+      vertex -9.48148 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75551 -22.9444 10
+      vertex -5.17638 -19.3185 10
+      vertex -9.55065 -22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -20 10
+      vertex -9.75551 -22.9444 10
+      vertex -10.0882 -23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5359 -24.1123 10
+      vertex 0 -20 10
+      vertex -10.0882 -23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.0814 -24.56 10
+      vertex 11.0814 -24.56 10
+      vertex -10.5359 -24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0814 -24.56 10
+      vertex -11.0814 -24.56 10
+      vertex 11.7038 -24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7038 -24.8927 10
+      vertex 11.7038 -24.8927 10
+      vertex -11.0814 -24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7038 -24.8927 10
+      vertex -11.7038 -24.8927 10
+      vertex 12.3792 -25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 -25.0976 10
+      vertex 12.3792 -25.0976 10
+      vertex -11.7038 -24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 -25.0976 10
+      vertex -12.3792 -25.0976 10
+      vertex 14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8492 -25.4558 10
+      vertex -12.3792 -25.0976 10
+      vertex -13.0815 -25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3792 -25.0976 10
+      vertex -14.8492 -25.4558 10
+      vertex 14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7838 -25.0976 10
+      vertex -14.8492 -25.4558 10
+      vertex -13.0815 -25.1668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4591 -24.8927 10
+      vertex -14.8492 -25.4558 10
+      vertex -13.7838 -25.0976 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0815 -24.56 10
+      vertex -14.8492 -25.4558 10
+      vertex -14.4591 -24.8927 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6271 -24.1123 10
+      vertex -14.8492 -25.4558 10
+      vertex -15.0815 -24.56 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 -23.5668 10
+      vertex -14.8492 -25.4558 10
+      vertex -15.6271 -24.1123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2068 -18.9139 10
+      vertex -16.6123 -20.8644 10
+      vertex -18.0312 -18.9312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 -20.8644 10
+      vertex -18.2068 -18.9139 10
+      vertex -16.6815 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3756 -18.8627 10
+      vertex -16.6815 -21.5668 10
+      vertex -18.2068 -18.9139 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5312 -18.7795 10
+      vertex -16.6815 -21.5668 10
+      vertex -18.3756 -18.8627 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6815 -21.5668 10
+      vertex -18.5312 -18.7795 10
+      vertex -16.6123 -22.2691 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6676 -18.6676 10
+      vertex -16.6123 -22.2691 10
+      vertex -18.5312 -18.7795 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 -16.6123 10
+      vertex -16.6123 -22.2691 10
+      vertex -18.6676 -18.6676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 -16.6123 10
+      vertex -18.6676 -18.6676 10
+      vertex -18.7795 -18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6123 -22.2691 10
+      vertex -22.2691 -16.6123 10
+      vertex -16.4074 -22.9444 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.1891 -16.4074 10
+      vertex -18.9139 -17.8556 10
+      vertex -19.5667 -16.0748 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8644 -16.6123 10
+      vertex -18.9139 -17.8556 10
+      vertex -20.1891 -16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9139 -17.8556 10
+      vertex -20.8644 -16.6123 10
+      vertex -18.9312 -18.0312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9312 -18.0312 10
+      vertex -20.8644 -16.6123 10
+      vertex -18.9139 -18.2068 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5668 -16.6815 10
+      vertex -18.9139 -18.2068 10
+      vertex -20.8644 -16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9139 -18.2068 10
+      vertex -21.5668 -16.6815 10
+      vertex -18.8627 -18.3756 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.8627 -18.3756 10
+      vertex -21.5668 -16.6815 10
+      vertex -18.7795 -18.5312 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2691 -16.6123 10
+      vertex -18.7795 -18.5312 10
+      vertex -21.5668 -16.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9444 -16.4074 10
+      vertex -16.4074 -22.9444 10
+      vertex -22.2691 -16.6123 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4074 -22.9444 10
+      vertex -22.9444 -16.4074 10
+      vertex -16.0748 -23.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 -16.0748 10
+      vertex -16.0748 -23.5668 10
+      vertex -22.9444 -16.4074 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0748 -23.5668 10
+      vertex -23.5668 -16.0748 10
+      vertex -14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.4558 -14.8492 10
+      vertex -23.5668 -16.0748 10
+      vertex -24.1123 -15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.5668 -16.0748 10
+      vertex -25.4558 -14.8492 10
+      vertex -14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.56 -15.0815 10
+      vertex -25.4558 -14.8492 10
+      vertex -24.1123 -15.6271 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8927 -14.4591 10
+      vertex -25.4558 -14.8492 10
+      vertex -24.56 -15.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 -13.7838 10
+      vertex -25.4558 -14.8492 10
+      vertex -24.8927 -14.4591 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.1668 -13.0815 10
+      vertex -25.4558 -14.8492 10
+      vertex -25.0976 -13.7838 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0976 -12.3792 10
+      vertex -25.4558 -14.8492 10
+      vertex -25.1668 -13.0815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8644 -9.55065 10
+      vertex 19.3185 -5.17638 10
+      vertex 20.1891 -9.75551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1891 -9.75551 10
+      vertex 19.3185 -5.17638 10
+      vertex 19.5667 -10.0882 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.3205 -10 10
+      vertex 19.5667 -10.0882 10
+      vertex 19.3185 -5.17638 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 -10.0882 10
+      vertex 17.3205 -10 10
+      vertex 19.0212 -10.5359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 -10.5359 10
+      vertex 17.3205 -10 10
+      vertex 18.5735 -11.0814 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 -11.0814 10
+      vertex 17.3205 -10 10
+      vertex 18.2408 -11.7038 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 -14.4591 10
+      vertex 17.6418 -15.4601 10
+      vertex 17.8159 -15.4889 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 -14.1421 10
+      vertex 17.9668 -13.0815 10
+      vertex 18.0359 -12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 -14.4591 10
+      vertex 17.4655 -15.4659 10
+      vertex 17.6418 -15.4601 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2408 -11.7038 10
+      vertex 17.3205 -10 10
+      vertex 18.0359 -12.3792 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 -14.1421 10
+      vertex 18.0359 -12.3792 10
+      vertex 17.3205 -10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 -13.7838 10
+      vertex 17.2936 -15.506 10
+      vertex 17.4655 -15.4659 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 -13.7838 10
+      vertex 14.1421 -14.1421 10
+      vertex 17.1329 -15.5788 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0359 -13.7838 10
+      vertex 17.1329 -15.5788 10
+      vertex 17.2936 -15.506 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.1329 -15.5788 10
+      vertex 14.1421 -14.1421 10
+      vertex 16.9895 -15.6815 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9895 -15.6815 10
+      vertex 14.1421 -14.1421 10
+      vertex 15.6815 -16.9895 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6815 -16.9895 10
+      vertex 14.1421 -14.1421 10
+      vertex 15.5788 -17.1329 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4591 -18.2408 10
+      vertex 15.4601 -17.6418 10
+      vertex 15.4659 -17.4655 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7838 -18.0359 10
+      vertex 15.4659 -17.4655 10
+      vertex 15.506 -17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7838 -18.0359 10
+      vertex 15.5788 -17.1329 10
+      vertex 14.1421 -14.1421 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5788 -17.1329 10
+      vertex 13.7838 -18.0359 10
+      vertex 15.506 -17.2936 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4889 -17.8159 10
+      vertex 14.4591 -18.2408 10
+      vertex 15.0815 -18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4659 -17.4655 10
+      vertex 13.7838 -18.0359 10
+      vertex 14.4591 -18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 -14.1421 10
+      vertex 13.0815 -17.9668 10
+      vertex 13.7838 -18.0359 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1421 -14.1421 10
+      vertex 12.3792 -18.0359 10
+      vertex 13.0815 -17.9668 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 -17.3205 10
+      vertex 12.3792 -18.0359 10
+      vertex 14.1421 -14.1421 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3792 -18.0359 10
+      vertex 10 -17.3205 10
+      vertex 11.7038 -18.2408 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7038 -18.2408 10
+      vertex 10 -17.3205 10
+      vertex 11.0814 -18.5735 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0814 -18.5735 10
+      vertex 10 -17.3205 10
+      vertex 10.5359 -19.0212 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5359 -19.0212 10
+      vertex 10 -17.3205 10
+      vertex 10.0882 -19.5667 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.17638 -19.3185 10
+      vertex 10.0882 -19.5667 10
+      vertex 10 -17.3205 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0882 -19.5667 10
+      vertex 5.17638 -19.3185 10
+      vertex 9.75551 -20.1891 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.55065 -20.8644 10
+      vertex 5.17638 -19.3185 10
+      vertex 9.48148 -21.5668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75551 -20.1891 10
+      vertex 5.17638 -19.3185 10
+      vertex 9.55065 -20.8644 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4352 16.0689 10
+      vertex 19.5667 16.0748 10
+      vertex 18.9139 17.8556 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5667 16.0748 10
+      vertex 18.4352 16.0689 10
+      vertex 19.0212 15.6271 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.3624 15.9082 10
+      vertex 19.0212 15.6271 10
+      vertex 18.4352 16.0689 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2596 15.7648 10
+      vertex 19.0212 15.6271 10
+      vertex 18.3624 15.9082 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0212 15.6271 10
+      vertex 18.2596 15.7648 10
+      vertex 18.5735 15.0815 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.1308 15.6442 10
+      vertex 18.5735 15.0815 10
+      vertex 18.2596 15.7648 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.981 15.551 10
+      vertex 18.5735 15.0815 10
+      vertex 18.1308 15.6442 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.8159 15.4889 10
+      vertex 18.5735 15.0815 10
+      vertex 17.981 15.551 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5735 15.0815 10
+      vertex 17.8159 15.4889 10
+      vertex 18.2408 14.4591 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6418 15.4601 10
+      vertex 18.2408 14.4591 10
+      vertex 17.8159 15.4889 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4655 15.4659 10
+      vertex 18.2408 14.4591 10
+      vertex 17.6418 15.4601 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex 14.8492 -25.4558 10
+      vertex -14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 14.8492 -25.4558 10
+      vertex -14.8492 -25.4558 0
+      vertex 14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 14.8492 -25.4558 10
+      vertex 25.4558 -14.8492 0
+      vertex 25.4558 -14.8492 10
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 14.8492 -25.4558 10
+      vertex 14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -14.8492 25.4558 10
+      vertex -14.8492 25.4558 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -14.8492 25.4558 10
+      vertex -25.4558 14.8492 0
+      vertex -25.4558 14.8492 10
+    endloop
+  endfacet
   facet normal -1 0 0
     outer loop
       vertex -25.4558 -14.8492 0
@@ -15705,3100 +15775,6 @@ solid OpenSCAD_Model
       vertex -25.4558 14.8492 10
       vertex -25.4558 -14.8492 0
       vertex -25.4558 -14.8492 10
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -19.8013 12.7303 0
-      vertex -19.7668 13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -19.9038 12.3926 0
-      vertex -19.8013 12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -22.8395 11.8087 0
-      vertex -19.3185 5.17638 0
-      vertex -20 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -20.0701 12.0814 0
-      vertex -19.9038 12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.8779 -11.4185 0
-      vertex -17.3205 -10 0
-      vertex -20.5667 -11.5848 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -17.3205 -10 0
-      vertex -20.8779 -11.4185 0
-      vertex -19.3185 -5.17638 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -20.294 11.8087 0
-      vertex -20.0701 12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.2156 -11.3161 0
-      vertex -19.3185 -5.17638 0
-      vertex -20.8779 -11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -20.5667 11.5848 0
-      vertex -20.294 11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.5668 -11.2815 0
-      vertex -19.3185 -5.17638 0
-      vertex -21.2156 -11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3205 10 0
-      vertex -20.8779 11.4185 0
-      vertex -20.5667 11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.9179 -11.3161 0
-      vertex -19.3185 -5.17638 0
-      vertex -21.5668 -11.2815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -21.2156 11.3161 0
-      vertex -20.8779 11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -22.2556 -11.4185 0
-      vertex -19.3185 -5.17638 0
-      vertex -21.9179 -11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -21.5668 11.2815 0
-      vertex -21.2156 11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -22.5668 -11.5848 0
-      vertex -19.3185 -5.17638 0
-      vertex -22.2556 -11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -21.9179 11.3161 0
-      vertex -21.5668 11.2815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -22.8395 -11.8087 0
-      vertex -19.3185 -5.17638 0
-      vertex -22.5668 -11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -22.2556 11.4185 0
-      vertex -21.9179 11.3161 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -19.3185 -5.17638 0
-      vertex -22.8395 -11.8087 0
-      vertex -20 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -22.5668 11.5848 0
-      vertex -22.2556 11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.0634 -12.0814 0
-      vertex -20 0 0
-      vertex -22.8395 -11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.3185 5.17638 0
-      vertex -22.8395 11.8087 0
-      vertex -22.5668 11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 -14.8492 0
-      vertex -20 0 0
-      vertex -23.0634 -12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20 0 0
-      vertex -23.0634 12.0814 0
-      vertex -22.8395 11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 -14.8492 0
-      vertex -23.0634 -12.0814 0
-      vertex -23.2297 -12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -20 0 0
-      vertex -25.4558 -14.8492 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 -14.8492 0
-      vertex -23.2297 -12.3926 0
-      vertex -23.3322 -12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20 0 0
-      vertex -25.4558 14.8492 0
-      vertex -23.0634 12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 -14.8492 0
-      vertex -23.3322 -12.7303 0
-      vertex -23.3668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.0634 12.0814 0
-      vertex -25.4558 14.8492 0
-      vertex -23.2297 12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.9038 -12.3926 0
-      vertex -17.3205 -10 0
-      vertex -19.8013 -12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.0701 -12.0814 0
-      vertex -17.3205 -10 0
-      vertex -19.9038 -12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.294 -11.8087 0
-      vertex -17.3205 -10 0
-      vertex -20.0701 -12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.5667 -11.5848 0
-      vertex -17.3205 -10 0
-      vertex -20.294 -11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 19.3185 0
-      vertex -11.3161 21.2156 0
-      vertex -11.2815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 19.3185 0
-      vertex -11.4185 20.8779 0
-      vertex -11.3161 21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -11.5848 20.5667 0
-      vertex -11.4185 20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -11.8087 20.294 0
-      vertex -11.5848 20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -12.0814 20.0701 0
-      vertex -11.8087 20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -12.3926 19.9038 0
-      vertex -12.0814 20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -12.7303 19.8013 0
-      vertex -12.3926 19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 17.3205 0
-      vertex -13.0815 19.7668 0
-      vertex -12.7303 19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -13.0815 19.7668 0
-      vertex -10 17.3205 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.0815 19.7668 0
-      vertex -15.8991 17.3241 0
-      vertex -13.4326 19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9265 17.6021 0
-      vertex -13.4326 19.8013 0
-      vertex -15.8991 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9265 17.0461 0
-      vertex -13.0815 19.7668 0
-      vertex -14.1421 14.1421 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.4326 19.8013 0
-      vertex -15.9265 17.6021 0
-      vertex -13.7703 19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0076 17.8694 0
-      vertex -13.7703 19.9038 0
-      vertex -15.9265 17.6021 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.7703 19.9038 0
-      vertex -16.0076 17.8694 0
-      vertex -14.0815 20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1393 18.1158 0
-      vertex -14.0815 20.0701 0
-      vertex -16.0076 17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.3165 18.3317 0
-      vertex -14.3543 20.294 0
-      vertex -16.1393 18.1158 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.0815 20.0701 0
-      vertex -16.1393 18.1158 0
-      vertex -14.3543 20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.0815 19.7668 0
-      vertex -15.9265 17.0461 0
-      vertex -15.8991 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -16.0076 16.7788 0
-      vertex -15.9265 17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -16.1393 16.5324 0
-      vertex -16.0076 16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -16.3165 16.3165 0
-      vertex -16.1393 16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -16.5324 16.1393 0
-      vertex -16.3165 16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -16.7788 16.0076 0
-      vertex -16.5324 16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -17.0461 15.9265 0
-      vertex -16.7788 16.0076 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.7668 13.0815 0
-      vertex -14.1421 14.1421 0
-      vertex -17.3205 10 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -19.7668 13.0815 0
-      vertex -17.0461 15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.0461 15.9265 0
-      vertex -19.7668 13.0815 0
-      vertex -17.3241 15.8991 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.8013 13.4326 0
-      vertex -17.3241 15.8991 0
-      vertex -19.7668 13.0815 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -17.3241 15.8991 0
-      vertex -19.8013 13.4326 0
-      vertex -17.6021 15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.9038 13.7703 0
-      vertex -17.6021 15.9265 0
-      vertex -19.8013 13.4326 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -17.6021 15.9265 0
-      vertex -19.9038 13.7703 0
-      vertex -17.8694 16.0076 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -17.8694 16.0076 0
-      vertex -20.0701 14.0815 0
-      vertex -18.1158 16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.294 14.3543 0
-      vertex -18.1158 16.1393 0
-      vertex -20.0701 14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.0701 14.0815 0
-      vertex -17.8694 16.0076 0
-      vertex -19.9038 13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.8779 11.4185 0
-      vertex -17.3205 10 0
-      vertex -19.3185 5.17638 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.4185 -20.8779 0
-      vertex -5.17638 -19.3185 0
-      vertex -11.3161 -21.2156 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -11.4185 -20.8779 0
-      vertex -10 -17.3205 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.5848 -20.5667 0
-      vertex -10 -17.3205 0
-      vertex -11.4185 -20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.8087 -20.294 0
-      vertex -10 -17.3205 0
-      vertex -11.5848 -20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.0814 -20.0701 0
-      vertex -10 -17.3205 0
-      vertex -11.8087 -20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.3926 -19.9038 0
-      vertex -10 -17.3205 0
-      vertex -12.0814 -20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.7303 -19.8013 0
-      vertex -10 -17.3205 0
-      vertex -12.3926 -19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.0815 -19.7668 0
-      vertex -10 -17.3205 0
-      vertex -12.7303 -19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8991 -17.3241 0
-      vertex -13.0815 -19.7668 0
-      vertex -13.4326 -19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9265 -17.6021 0
-      vertex -13.4326 -19.8013 0
-      vertex -13.7703 -19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0076 -17.8694 0
-      vertex -13.7703 -19.9038 0
-      vertex -14.0815 -20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9265 -17.0461 0
-      vertex -13.0815 -19.7668 0
-      vertex -15.8991 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1393 -18.1158 0
-      vertex -14.0815 -20.0701 0
-      vertex -14.3543 -20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.5324 -18.509 0
-      vertex -14.3543 -20.294 0
-      vertex -14.5781 -20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.7788 -18.6406 0
-      vertex -14.5781 -20.5667 0
-      vertex -14.7445 -20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.0461 -18.7217 0
-      vertex -14.7445 -20.8779 0
-      vertex -14.8469 -21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3241 -18.7491 0
-      vertex -14.8469 -21.2156 0
-      vertex -14.8815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.4326 -19.8013 0
-      vertex -15.9265 -17.6021 0
-      vertex -15.8991 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.0815 -19.7668 0
-      vertex -15.9265 -17.0461 0
-      vertex -14.1421 -14.1421 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0076 -16.7788 0
-      vertex -14.1421 -14.1421 0
-      vertex -15.9265 -17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1393 -16.5324 0
-      vertex -14.1421 -14.1421 0
-      vertex -16.0076 -16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.3165 -16.3165 0
-      vertex -14.1421 -14.1421 0
-      vertex -16.1393 -16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.5324 -16.1393 0
-      vertex -14.1421 -14.1421 0
-      vertex -16.3165 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.7788 -16.0076 0
-      vertex -14.1421 -14.1421 0
-      vertex -16.5324 -16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.0461 -15.9265 0
-      vertex -14.1421 -14.1421 0
-      vertex -16.7788 -16.0076 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.7668 -13.0815 0
-      vertex -14.1421 -14.1421 0
-      vertex -17.0461 -15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.7668 -13.0815 0
-      vertex -17.0461 -15.9265 0
-      vertex -17.3241 -15.8991 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.8013 -13.4326 0
-      vertex -17.3241 -15.8991 0
-      vertex -17.6021 -15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.9038 -13.7703 0
-      vertex -17.6021 -15.9265 0
-      vertex -17.8694 -16.0076 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.0701 -14.0815 0
-      vertex -17.8694 -16.0076 0
-      vertex -18.1158 -16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.294 -14.3543 0
-      vertex -18.1158 -16.1393 0
-      vertex -18.3317 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.294 -14.3543 0
-      vertex -18.3317 -16.3165 0
-      vertex -18.509 -16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.5667 -14.5781 0
-      vertex -18.509 -16.5324 0
-      vertex -18.6406 -16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.8779 -14.7445 0
-      vertex -18.6406 -16.7788 0
-      vertex -18.7217 -17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3241 -15.8991 0
-      vertex -19.8013 -13.4326 0
-      vertex -19.7668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.2156 -14.8469 0
-      vertex -18.7217 -17.0461 0
-      vertex -18.7491 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.2156 14.8469 0
-      vertex 18.7217 17.0461 0
-      vertex 18.7491 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 18.6406 16.7788 0
-      vertex 18.7217 17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 18.509 16.5324 0
-      vertex 18.6406 16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 14.1421 0
-      vertex 19.8013 12.7303 0
-      vertex 17.3205 10 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 18.3317 16.3165 0
-      vertex 18.509 16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 18.1158 16.1393 0
-      vertex 18.3317 16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 17.8694 16.0076 0
-      vertex 18.1158 16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 17.6021 15.9265 0
-      vertex 17.8694 16.0076 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 17.3241 15.8991 0
-      vertex 17.6021 15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 17.0461 15.9265 0
-      vertex 17.3241 15.8991 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 12.7303 0
-      vertex 14.1421 14.1421 0
-      vertex 17.0461 15.9265 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 17.0461 15.9265 0
-      vertex 14.1421 14.1421 0
-      vertex 16.7788 16.0076 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.7788 16.0076 0
-      vertex 14.1421 14.1421 0
-      vertex 16.5324 16.1393 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.5324 16.1393 0
-      vertex 14.1421 14.1421 0
-      vertex 16.3165 16.3165 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.3165 16.3165 0
-      vertex 14.1421 14.1421 0
-      vertex 16.1393 16.5324 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.1393 16.5324 0
-      vertex 14.1421 14.1421 0
-      vertex 16.0076 16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.0815 19.7668 0
-      vertex 15.8991 17.3241 0
-      vertex 15.9265 17.0461 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.0076 16.7788 0
-      vertex 14.1421 14.1421 0
-      vertex 15.9265 17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 14.8469 21.2156 0
-      vertex 14.8815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 14.7445 20.8779 0
-      vertex 14.8469 21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 14.5781 20.5667 0
-      vertex 14.7445 20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.0815 19.7668 0
-      vertex 15.9265 17.0461 0
-      vertex 14.1421 14.1421 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 14.3543 20.294 0
-      vertex 14.5781 20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 14.0815 20.0701 0
-      vertex 14.3543 20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 13.7703 19.9038 0
-      vertex 14.0815 20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 13.4326 19.8013 0
-      vertex 13.7703 19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8991 17.3241 0
-      vertex 13.0815 19.7668 0
-      vertex 13.4326 19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 17.3205 0
-      vertex 13.0815 19.7668 0
-      vertex 14.1421 14.1421 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.0815 19.7668 0
-      vertex 10 17.3205 0
-      vertex 12.7303 19.8013 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.7303 19.8013 0
-      vertex 10 17.3205 0
-      vertex 12.3926 19.9038 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.3926 19.9038 0
-      vertex 10 17.3205 0
-      vertex 12.0814 20.0701 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.0814 20.0701 0
-      vertex 10 17.3205 0
-      vertex 11.8087 20.294 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.8087 20.294 0
-      vertex 10 17.3205 0
-      vertex 11.5848 20.5667 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.4185 20.8779 0
-      vertex 5.17638 19.3185 0
-      vertex 11.3161 21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 19.3185 0
-      vertex 11.4185 20.8779 0
-      vertex 10 17.3205 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.5848 20.5667 0
-      vertex 10 17.3205 0
-      vertex 11.4185 20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.8694 -16.0076 0
-      vertex 20.0701 -14.0815 0
-      vertex 18.1158 -16.1393 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.0701 -14.0815 0
-      vertex 17.8694 -16.0076 0
-      vertex 19.9038 -13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.6021 -15.9265 0
-      vertex 19.9038 -13.7703 0
-      vertex 17.8694 -16.0076 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 19.9038 -13.7703 0
-      vertex 17.6021 -15.9265 0
-      vertex 19.8013 -13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.3241 -15.8991 0
-      vertex 19.8013 -13.4326 0
-      vertex 17.6021 -15.9265 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 19.8013 -13.4326 0
-      vertex 17.3241 -15.8991 0
-      vertex 19.7668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.0461 -15.9265 0
-      vertex 19.7668 -13.0815 0
-      vertex 17.3241 -15.8991 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 19.7668 -13.0815 0
-      vertex 17.0461 -15.9265 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.8013 -12.7303 0
-      vertex 17.3205 -10 0
-      vertex 19.3185 -5.17638 0
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 17.3205 -10 0
-      vertex 19.7668 -13.0815 0
-      vertex 14.1421 -14.1421 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 17.0461 -15.9265 0
-      vertex 16.7788 -16.0076 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 16.7788 -16.0076 0
-      vertex 16.5324 -16.1393 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 16.5324 -16.1393 0
-      vertex 16.3165 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 16.3165 -16.3165 0
-      vertex 16.1393 -16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 16.1393 -16.5324 0
-      vertex 16.0076 -16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 16.0076 -16.7788 0
-      vertex 15.9265 -17.0461 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.3165 -18.3317 0
-      vertex 14.3543 -20.294 0
-      vertex 16.1393 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0815 -20.0701 0
-      vertex 16.1393 -18.1158 0
-      vertex 14.3543 -20.294 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.1393 -18.1158 0
-      vertex 14.0815 -20.0701 0
-      vertex 16.0076 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.7703 -19.9038 0
-      vertex 16.0076 -17.8694 0
-      vertex 14.0815 -20.0701 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.0076 -17.8694 0
-      vertex 13.7703 -19.9038 0
-      vertex 15.9265 -17.6021 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.4326 -19.8013 0
-      vertex 15.9265 -17.6021 0
-      vertex 13.7703 -19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.7668 -13.0815 0
-      vertex 17.3205 -10 0
-      vertex 19.8013 -12.7303 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.9265 -17.6021 0
-      vertex 13.4326 -19.8013 0
-      vertex 15.8991 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.0815 -19.7668 0
-      vertex 15.8991 -17.3241 0
-      vertex 13.4326 -19.8013 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.8991 -17.3241 0
-      vertex 13.0815 -19.7668 0
-      vertex 15.9265 -17.0461 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.9265 -17.0461 0
-      vertex 13.0815 -19.7668 0
-      vertex 14.1421 -14.1421 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 13.0815 -19.7668 0
-      vertex 12.7303 -19.8013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 12.7303 -19.8013 0
-      vertex 12.3926 -19.9038 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 12.3926 -19.9038 0
-      vertex 12.0814 -20.0701 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 12.0814 -20.0701 0
-      vertex 11.8087 -20.294 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 11.8087 -20.294 0
-      vertex 11.5848 -20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 11.5848 -20.5667 0
-      vertex 11.4185 -20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.0815 -19.7668 0
-      vertex 10 -17.3205 0
-      vertex 14.1421 -14.1421 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 -19.3185 0
-      vertex 11.4185 -20.8779 0
-      vertex 11.3161 -21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 -19.3185 0
-      vertex 11.3161 -21.2156 0
-      vertex 11.2815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.0634 -12.0814 0
-      vertex 25.4558 -14.8492 0
-      vertex 23.2297 -12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 14.8492 0
-      vertex 23.3322 12.7303 0
-      vertex 23.3668 13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 20 0 0
-      vertex 25.4558 -14.8492 0
-      vertex 23.0634 -12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 14.8492 0
-      vertex 23.2297 12.3926 0
-      vertex 23.3322 12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 20 0 0
-      vertex 25.4558 14.8492 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 14.8492 0
-      vertex 23.0634 12.0814 0
-      vertex 23.2297 12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 20 0 0
-      vertex 23.0634 -12.0814 0
-      vertex 22.8395 -11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 14.8492 0
-      vertex 20 0 0
-      vertex 23.0634 12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 22.8395 -11.8087 0
-      vertex 22.5668 -11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.0634 12.0814 0
-      vertex 20 0 0
-      vertex 22.8395 11.8087 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 22.5668 -11.5848 0
-      vertex 22.2556 -11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 5.17638 0
-      vertex 22.8395 11.8087 0
-      vertex 20 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 22.2556 -11.4185 0
-      vertex 21.9179 -11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.8395 11.8087 0
-      vertex 19.3185 5.17638 0
-      vertex 22.5668 11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 21.9179 -11.3161 0
-      vertex 21.5668 -11.2815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5668 11.5848 0
-      vertex 19.3185 5.17638 0
-      vertex 22.2556 11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 21.5668 -11.2815 0
-      vertex 21.2156 -11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.2556 11.4185 0
-      vertex 19.3185 5.17638 0
-      vertex 21.9179 11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 21.2156 -11.3161 0
-      vertex 20.8779 -11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9179 11.3161 0
-      vertex 19.3185 5.17638 0
-      vertex 21.5668 11.2815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 20.8779 -11.4185 0
-      vertex 20.5667 -11.5848 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.5668 11.2815 0
-      vertex 19.3185 5.17638 0
-      vertex 21.2156 11.3161 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 20.5667 -11.5848 0
-      vertex 20.294 -11.8087 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.2156 11.3161 0
-      vertex 19.3185 5.17638 0
-      vertex 20.8779 11.4185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 20.294 -11.8087 0
-      vertex 20.0701 -12.0814 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.3205 10 0
-      vertex 20.8779 11.4185 0
-      vertex 19.3185 5.17638 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.8779 11.4185 0
-      vertex 17.3205 10 0
-      vertex 20.5667 11.5848 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 20.0701 -12.0814 0
-      vertex 19.9038 -12.3926 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 19.3185 -5.17638 0
-      vertex 19.9038 -12.3926 0
-      vertex 19.8013 -12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.1158 -16.1393 0
-      vertex 20.294 -14.3543 0
-      vertex 18.3317 -16.3165 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.8395 -11.8087 0
-      vertex 19.3185 -5.17638 0
-      vertex 20 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.3322 -12.7303 0
-      vertex 25.4558 -14.8492 0
-      vertex 23.3668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 23.3322 -13.4326 0
-      vertex 23.3668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 23.2297 -13.7703 0
-      vertex 23.3322 -13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 23.0634 -14.0815 0
-      vertex 23.2297 -13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 22.8395 -14.3543 0
-      vertex 23.0634 -14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 22.5668 -14.5781 0
-      vertex 22.8395 -14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 22.2556 -14.7445 0
-      vertex 22.5668 -14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 21.9179 -14.8469 0
-      vertex 22.2556 -14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.6406 -17.8694 0
-      vertex 21.9179 -14.8469 0
-      vertex 25.4558 -14.8492 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.294 -14.3543 0
-      vertex 18.1158 -16.1393 0
-      vertex 20.0701 -14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.3317 -16.3165 0
-      vertex 20.294 -14.3543 0
-      vertex 18.509 -16.5324 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.5667 -14.5781 0
-      vertex 18.509 -16.5324 0
-      vertex 20.294 -14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.509 -16.5324 0
-      vertex 20.5667 -14.5781 0
-      vertex 18.6406 -16.7788 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.8779 -14.7445 0
-      vertex 18.6406 -16.7788 0
-      vertex 20.5667 -14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.6406 -16.7788 0
-      vertex 20.8779 -14.7445 0
-      vertex 18.7217 -17.0461 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.2156 -14.8469 0
-      vertex 18.7217 -17.0461 0
-      vertex 20.8779 -14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 -17.0461 0
-      vertex 21.2156 -14.8469 0
-      vertex 18.7491 -17.3241 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.5668 -14.8815 0
-      vertex 18.7491 -17.3241 0
-      vertex 21.2156 -14.8469 0
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 18.7217 -17.6021 0
-      vertex 21.9179 -14.8469 0
-      vertex 18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.5668 -14.8815 0
-      vertex 18.7217 -17.6021 0
-      vertex 18.7491 -17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9179 -14.8469 0
-      vertex 18.7217 -17.6021 0
-      vertex 21.5668 -14.8815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 18.509 -18.1158 0
-      vertex 18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 25.4558 -14.8492 0
-      vertex 18.3317 -18.3317 0
-      vertex 18.509 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 18.3317 -18.3317 0
-      vertex 25.4558 -14.8492 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.3317 -18.3317 0
-      vertex 14.8492 -25.4558 0
-      vertex 18.1158 -18.509 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.5324 -18.509 0
-      vertex 14.3543 -20.294 0
-      vertex 16.3165 -18.3317 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3543 -20.294 0
-      vertex 16.5324 -18.509 0
-      vertex 14.5781 -20.5667 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.7788 -18.6406 0
-      vertex 14.5781 -20.5667 0
-      vertex 16.5324 -18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.5781 -20.5667 0
-      vertex 16.7788 -18.6406 0
-      vertex 14.7445 -20.8779 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 17.0461 -18.7217 0
-      vertex 14.7445 -20.8779 0
-      vertex 16.7788 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.7445 -20.8779 0
-      vertex 17.0461 -18.7217 0
-      vertex 14.8469 -21.2156 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 17.3241 -18.7491 0
-      vertex 14.8469 -21.2156 0
-      vertex 17.0461 -18.7217 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8469 -21.2156 0
-      vertex 17.3241 -18.7491 0
-      vertex 14.8815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.6021 -18.7217 0
-      vertex 14.8815 -21.5668 0
-      vertex 17.3241 -18.7491 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8469 -21.9179 0
-      vertex 17.6021 -18.7217 0
-      vertex 17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.1158 -18.509 0
-      vertex 14.8492 -25.4558 0
-      vertex 17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.8694 -18.6406 0
-      vertex 14.8492 -25.4558 0
-      vertex 14.8469 -21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.6021 -18.7217 0
-      vertex 14.8469 -21.9179 0
-      vertex 14.8815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 14.7445 -22.2556 0
-      vertex 14.8469 -21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 14.5781 -22.5668 0
-      vertex 14.7445 -22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 14.3543 -22.8395 0
-      vertex 14.5781 -22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 14.0815 -23.0634 0
-      vertex 14.3543 -22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 13.7703 -23.2297 0
-      vertex 14.0815 -23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 13.4326 -23.3322 0
-      vertex 13.7703 -23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 13.0815 -23.3668 0
-      vertex 13.4326 -23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 12.7303 -23.3322 0
-      vertex 13.0815 -23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 12.3926 -23.2297 0
-      vertex 12.7303 -23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 -25.4558 0
-      vertex 12.0814 -23.0634 0
-      vertex 12.3926 -23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 -20 0
-      vertex 12.0814 -23.0634 0
-      vertex 14.8492 -25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 -19.3185 0
-      vertex 11.2815 -21.5668 0
-      vertex 11.3161 -21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.4185 -20.8779 0
-      vertex 5.17638 -19.3185 0
-      vertex 10 -17.3205 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.4185 -22.2556 0
-      vertex 5.17638 -19.3185 0
-      vertex 11.3161 -21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5848 -22.5668 0
-      vertex 5.17638 -19.3185 0
-      vertex 11.4185 -22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.8087 -22.8395 0
-      vertex 5.17638 -19.3185 0
-      vertex 11.5848 -22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.0814 -23.0634 0
-      vertex 0 -20 0
-      vertex 11.8087 -22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.8087 -22.8395 0
-      vertex 0 -20 0
-      vertex 5.17638 -19.3185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex 0 -20 0
-      vertex 14.8492 -25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.3161 -21.2156 0
-      vertex -5.17638 -19.3185 0
-      vertex -11.2815 -21.5668 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0 -20 0
-      vertex -11.8087 -22.8395 0
-      vertex -5.17638 -19.3185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -11.3161 -21.9179 0
-      vertex -11.2815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -11.4185 -22.2556 0
-      vertex -11.3161 -21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -11.5848 -22.5668 0
-      vertex -11.4185 -22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -11.8087 -22.8395 0
-      vertex -11.5848 -22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 -20 0
-      vertex -12.0814 -23.0634 0
-      vertex -11.8087 -22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 -20 0
-      vertex -14.8492 -25.4558 0
-      vertex -12.0814 -23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.0814 -23.0634 0
-      vertex -14.8492 -25.4558 0
-      vertex -12.3926 -23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.3926 -23.2297 0
-      vertex -14.8492 -25.4558 0
-      vertex -12.7303 -23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.7303 -23.3322 0
-      vertex -14.8492 -25.4558 0
-      vertex -13.0815 -23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -13.4326 -23.3322 0
-      vertex -13.0815 -23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -13.7703 -23.2297 0
-      vertex -13.4326 -23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -14.0815 -23.0634 0
-      vertex -13.7703 -23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -14.3543 -22.8395 0
-      vertex -14.0815 -23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -14.5781 -22.5668 0
-      vertex -14.3543 -22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -14.7445 -22.2556 0
-      vertex -14.5781 -22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -14.8469 -21.9179 0
-      vertex -14.7445 -22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.8694 -18.6406 0
-      vertex -14.8469 -21.9179 0
-      vertex -14.8492 -25.4558 0
-    endloop
-  endfacet
-  facet normal -0 -0 -1
-    outer loop
-      vertex -17.6021 -18.7217 0
-      vertex -14.8469 -21.9179 0
-      vertex -17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.0815 -19.7668 0
-      vertex -14.1421 -14.1421 0
-      vertex -10 -17.3205 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.7703 -19.9038 0
-      vertex -16.0076 -17.8694 0
-      vertex -15.9265 -17.6021 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.0815 -20.0701 0
-      vertex -16.1393 -18.1158 0
-      vertex -16.0076 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3543 -20.294 0
-      vertex -16.3165 -18.3317 0
-      vertex -16.1393 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3543 -20.294 0
-      vertex -16.5324 -18.509 0
-      vertex -16.3165 -18.3317 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.5781 -20.5667 0
-      vertex -16.7788 -18.6406 0
-      vertex -16.5324 -18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.7445 -20.8779 0
-      vertex -17.0461 -18.7217 0
-      vertex -16.7788 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8469 -21.2156 0
-      vertex -17.3241 -18.7491 0
-      vertex -17.0461 -18.7217 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8815 -21.5668 0
-      vertex -17.6021 -18.7217 0
-      vertex -17.3241 -18.7491 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8469 -21.9179 0
-      vertex -17.6021 -18.7217 0
-      vertex -14.8815 -21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -18.1158 -18.509 0
-      vertex -17.8694 -18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 -25.4558 0
-      vertex -18.3317 -18.3317 0
-      vertex -18.1158 -18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 -14.8492 0
-      vertex -18.3317 -18.3317 0
-      vertex -14.8492 -25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.3317 -18.3317 0
-      vertex -25.4558 -14.8492 0
-      vertex -18.509 -18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.8013 -12.7303 0
-      vertex -17.3205 -10 0
-      vertex -19.7668 -13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.5668 -14.8815 0
-      vertex -18.7491 -17.3241 0
-      vertex -18.7217 -17.6021 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1421 -14.1421 0
-      vertex -19.7668 -13.0815 0
-      vertex -17.3205 -10 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.6021 -15.9265 0
-      vertex -19.9038 -13.7703 0
-      vertex -19.8013 -13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.9179 -14.8469 0
-      vertex -18.7217 -17.6021 0
-      vertex -18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.8694 -16.0076 0
-      vertex -20.0701 -14.0815 0
-      vertex -19.9038 -13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.1158 -16.1393 0
-      vertex -20.294 -14.3543 0
-      vertex -20.0701 -14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.509 -16.5324 0
-      vertex -20.5667 -14.5781 0
-      vertex -20.294 -14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.509 -18.1158 0
-      vertex -25.4558 -14.8492 0
-      vertex -18.6406 -17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.6406 -16.7788 0
-      vertex -20.8779 -14.7445 0
-      vertex -20.5667 -14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.7217 -17.0461 0
-      vertex -21.2156 -14.8469 0
-      vertex -20.8779 -14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.7491 -17.3241 0
-      vertex -21.5668 -14.8815 0
-      vertex -21.2156 -14.8469 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.7217 -17.6021 0
-      vertex -21.9179 -14.8469 0
-      vertex -21.5668 -14.8815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.6406 -17.8694 0
-      vertex -25.4558 -14.8492 0
-      vertex -21.9179 -14.8469 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -21.9179 -14.8469 0
-      vertex -25.4558 -14.8492 0
-      vertex -22.2556 -14.7445 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -22.2556 -14.7445 0
-      vertex -25.4558 -14.8492 0
-      vertex -22.5668 -14.5781 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -22.5668 -14.5781 0
-      vertex -25.4558 -14.8492 0
-      vertex -22.8395 -14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.2297 12.3926 0
-      vertex -25.4558 14.8492 0
-      vertex -23.3322 12.7303 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -23.3322 -13.4326 0
-      vertex -25.4558 -14.8492 0
-      vertex -23.3668 -13.0815 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -23.2297 -13.7703 0
-      vertex -25.4558 -14.8492 0
-      vertex -23.3322 -13.4326 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -23.0634 -14.0815 0
-      vertex -25.4558 -14.8492 0
-      vertex -23.2297 -13.7703 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -22.8395 -14.3543 0
-      vertex -25.4558 -14.8492 0
-      vertex -23.0634 -14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2297 -12.3926 0
-      vertex 25.4558 -14.8492 0
-      vertex 23.3322 -12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.3322 13.4326 0
-      vertex 25.4558 14.8492 0
-      vertex 23.3668 13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2297 13.7703 0
-      vertex 25.4558 14.8492 0
-      vertex 23.3322 13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.0634 14.0815 0
-      vertex 25.4558 14.8492 0
-      vertex 23.2297 13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.8395 14.3543 0
-      vertex 25.4558 14.8492 0
-      vertex 23.0634 14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5668 14.5781 0
-      vertex 25.4558 14.8492 0
-      vertex 22.8395 14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.2556 14.7445 0
-      vertex 25.4558 14.8492 0
-      vertex 22.5668 14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9179 14.8469 0
-      vertex 25.4558 14.8492 0
-      vertex 22.2556 14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.6021 0
-      vertex 21.9179 14.8469 0
-      vertex 21.5668 14.8815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 19.7668 13.0815 0
-      vertex 19.8013 12.7303 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 19.8013 13.4326 0
-      vertex 19.7668 13.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 19.9038 13.7703 0
-      vertex 19.8013 13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 20.0701 14.0815 0
-      vertex 19.9038 13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 20.294 14.3543 0
-      vertex 20.0701 14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 20.5667 14.5781 0
-      vertex 20.294 14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 20.8779 14.7445 0
-      vertex 20.5667 14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.0461 0
-      vertex 21.2156 14.8469 0
-      vertex 20.8779 14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7491 17.3241 0
-      vertex 21.5668 14.8815 0
-      vertex 21.2156 14.8469 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.7217 17.6021 0
-      vertex 21.5668 14.8815 0
-      vertex 18.7491 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9179 14.8469 0
-      vertex 18.7217 17.6021 0
-      vertex 18.6406 17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9179 14.8469 0
-      vertex 18.6406 17.8694 0
-      vertex 25.4558 14.8492 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.509 18.1158 0
-      vertex 25.4558 14.8492 0
-      vertex 18.6406 17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.3317 18.3317 0
-      vertex 25.4558 14.8492 0
-      vertex 18.509 18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 25.4558 0
-      vertex 18.3317 18.3317 0
-      vertex 18.1158 18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8492 25.4558 0
-      vertex 18.1158 18.509 0
-      vertex 17.8694 18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 15.9265 17.6021 0
-      vertex 15.8991 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 16.0076 17.8694 0
-      vertex 15.9265 17.6021 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 16.1393 18.1158 0
-      vertex 16.0076 17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 16.3165 18.3317 0
-      vertex 16.1393 18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 16.5324 18.509 0
-      vertex 16.3165 18.3317 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 16.7788 18.6406 0
-      vertex 16.5324 18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 17.0461 18.7217 0
-      vertex 16.7788 18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 17.3241 18.7491 0
-      vertex 17.0461 18.7217 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8815 21.5668 0
-      vertex 17.6021 18.7217 0
-      vertex 17.3241 18.7491 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8469 21.9179 0
-      vertex 17.6021 18.7217 0
-      vertex 14.8815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 17.6021 18.7217 0
-      vertex 14.8469 21.9179 0
-      vertex 17.8694 18.6406 0
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 14.8492 25.4558 0
-      vertex 17.8694 18.6406 0
-      vertex 14.8469 21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.3317 18.3317 0
-      vertex 14.8492 25.4558 0
-      vertex 25.4558 14.8492 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.7445 22.2556 0
-      vertex 14.8492 25.4558 0
-      vertex 14.8469 21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.5781 22.5668 0
-      vertex 14.8492 25.4558 0
-      vertex 14.7445 22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3543 22.8395 0
-      vertex 14.8492 25.4558 0
-      vertex 14.5781 22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0815 23.0634 0
-      vertex 14.8492 25.4558 0
-      vertex 14.3543 22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.7703 23.2297 0
-      vertex 14.8492 25.4558 0
-      vertex 14.0815 23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.4326 23.3322 0
-      vertex 14.8492 25.4558 0
-      vertex 13.7703 23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.0815 23.3668 0
-      vertex 14.8492 25.4558 0
-      vertex 13.4326 23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.7303 23.3322 0
-      vertex 14.8492 25.4558 0
-      vertex 13.0815 23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.3926 23.2297 0
-      vertex 14.8492 25.4558 0
-      vertex 12.7303 23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.0814 23.0634 0
-      vertex 14.8492 25.4558 0
-      vertex 12.3926 23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 20 0
-      vertex 12.0814 23.0634 0
-      vertex 11.8087 22.8395 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.3161 21.2156 0
-      vertex 5.17638 19.3185 0
-      vertex 11.2815 21.5668 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.2815 21.5668 0
-      vertex 5.17638 19.3185 0
-      vertex 11.3161 21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 19.3185 0
-      vertex 11.4185 22.2556 0
-      vertex 11.3161 21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 19.3185 0
-      vertex 11.5848 22.5668 0
-      vertex 11.4185 22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.17638 19.3185 0
-      vertex 11.8087 22.8395 0
-      vertex 11.5848 22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 20 0
-      vertex 11.8087 22.8395 0
-      vertex 5.17638 19.3185 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.0814 23.0634 0
-      vertex 0 20 0
-      vertex 14.8492 25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.8087 22.8395 0
-      vertex 0 20 0
-      vertex -5.17638 19.3185 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.4185 20.8779 0
-      vertex -5.17638 19.3185 0
-      vertex -10 17.3205 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.3161 21.9179 0
-      vertex -5.17638 19.3185 0
-      vertex -11.2815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.4185 22.2556 0
-      vertex -5.17638 19.3185 0
-      vertex -11.3161 21.9179 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.5848 22.5668 0
-      vertex -5.17638 19.3185 0
-      vertex -11.4185 22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.8087 22.8395 0
-      vertex -5.17638 19.3185 0
-      vertex -11.5848 22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.0814 23.0634 0
-      vertex 0 20 0
-      vertex -11.8087 22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 25.4558 0
-      vertex 0 20 0
-      vertex -12.0814 23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 25.4558 0
-      vertex -12.0814 23.0634 0
-      vertex -12.3926 23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 25.4558 0
-      vertex -12.3926 23.2297 0
-      vertex -12.7303 23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8492 25.4558 0
-      vertex -12.7303 23.3322 0
-      vertex -13.0815 23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 20 0
-      vertex -14.8492 25.4558 0
-      vertex 14.8492 25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.4326 23.3322 0
-      vertex -14.8492 25.4558 0
-      vertex -13.0815 23.3668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.7703 23.2297 0
-      vertex -14.8492 25.4558 0
-      vertex -13.4326 23.3322 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.0815 23.0634 0
-      vertex -14.8492 25.4558 0
-      vertex -13.7703 23.2297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3543 22.8395 0
-      vertex -14.8492 25.4558 0
-      vertex -14.0815 23.0634 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.5781 22.5668 0
-      vertex -14.8492 25.4558 0
-      vertex -14.3543 22.8395 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.7445 22.2556 0
-      vertex -14.8492 25.4558 0
-      vertex -14.5781 22.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8469 21.9179 0
-      vertex -14.8492 25.4558 0
-      vertex -14.7445 22.2556 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.6021 18.7217 0
-      vertex -14.8469 21.9179 0
-      vertex -14.8815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.5324 18.509 0
-      vertex -14.3543 20.294 0
-      vertex -16.3165 18.3317 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.3543 20.294 0
-      vertex -16.5324 18.509 0
-      vertex -14.5781 20.5667 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.7788 18.6406 0
-      vertex -14.5781 20.5667 0
-      vertex -16.5324 18.509 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.5781 20.5667 0
-      vertex -16.7788 18.6406 0
-      vertex -14.7445 20.8779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.0461 18.7217 0
-      vertex -14.7445 20.8779 0
-      vertex -16.7788 18.6406 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.7445 20.8779 0
-      vertex -17.0461 18.7217 0
-      vertex -14.8469 21.2156 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.3241 18.7491 0
-      vertex -14.8469 21.2156 0
-      vertex -17.0461 18.7217 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.8469 21.2156 0
-      vertex -17.3241 18.7491 0
-      vertex -14.8815 21.5668 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.6021 18.7217 0
-      vertex -14.8815 21.5668 0
-      vertex -17.3241 18.7491 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8469 21.9179 0
-      vertex -17.6021 18.7217 0
-      vertex -17.8694 18.6406 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.8469 21.9179 0
-      vertex -17.8694 18.6406 0
-      vertex -14.8492 25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.1158 18.509 0
-      vertex -14.8492 25.4558 0
-      vertex -17.8694 18.6406 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.3317 18.3317 0
-      vertex -14.8492 25.4558 0
-      vertex -18.1158 18.509 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -18.3317 18.3317 0
-      vertex -18.509 18.1158 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -18.509 18.1158 0
-      vertex -18.6406 17.8694 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.1158 16.1393 0
-      vertex -20.294 14.3543 0
-      vertex -18.3317 16.3165 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.3317 16.3165 0
-      vertex -20.294 14.3543 0
-      vertex -18.509 16.5324 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.5667 14.5781 0
-      vertex -18.509 16.5324 0
-      vertex -20.294 14.3543 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.509 16.5324 0
-      vertex -20.5667 14.5781 0
-      vertex -18.6406 16.7788 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -20.8779 14.7445 0
-      vertex -18.6406 16.7788 0
-      vertex -20.5667 14.5781 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.6406 16.7788 0
-      vertex -20.8779 14.7445 0
-      vertex -18.7217 17.0461 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.2156 14.8469 0
-      vertex -18.7217 17.0461 0
-      vertex -20.8779 14.7445 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.7217 17.0461 0
-      vertex -21.2156 14.8469 0
-      vertex -18.7491 17.3241 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.5668 14.8815 0
-      vertex -18.7491 17.3241 0
-      vertex -21.2156 14.8469 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.7491 17.3241 0
-      vertex -21.5668 14.8815 0
-      vertex -18.7217 17.6021 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -21.9179 14.8469 0
-      vertex -18.7217 17.6021 0
-      vertex -21.5668 14.8815 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.7217 17.6021 0
-      vertex -21.9179 14.8469 0
-      vertex -18.6406 17.8694 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -18.6406 17.8694 0
-      vertex -21.9179 14.8469 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -21.9179 14.8469 0
-      vertex -22.2556 14.7445 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -22.2556 14.7445 0
-      vertex -22.5668 14.5781 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -22.5668 14.5781 0
-      vertex -22.8395 14.3543 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -22.8395 14.3543 0
-      vertex -23.0634 14.0815 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -18.3317 18.3317 0
-      vertex -25.4558 14.8492 0
-      vertex -14.8492 25.4558 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.2297 13.7703 0
-      vertex -25.4558 14.8492 0
-      vertex -23.0634 14.0815 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.3322 13.4326 0
-      vertex -25.4558 14.8492 0
-      vertex -23.2297 13.7703 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.3668 13.0815 0
-      vertex -25.4558 14.8492 0
-      vertex -23.3322 13.4326 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -23.3322 12.7303 0
-      vertex -25.4558 14.8492 0
-      vertex -23.3668 13.0815 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.5667 11.5848 0
-      vertex 17.3205 10 0
-      vertex 20.294 11.8087 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.294 11.8087 0
-      vertex 17.3205 10 0
-      vertex 20.0701 12.0814 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20.0701 12.0814 0
-      vertex 17.3205 10 0
-      vertex 19.9038 12.3926 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 19.9038 12.3926 0
-      vertex 17.3205 10 0
-      vertex 19.8013 12.7303 0
-    endloop
-  endfacet
-  facet normal -0.707107 0.707107 0
-    outer loop
-      vertex -25.4558 14.8492 0
-      vertex -14.8492 25.4558 10
-      vertex -14.8492 25.4558 0
-    endloop
-  endfacet
-  facet normal -0.707107 0.707107 0
-    outer loop
-      vertex -14.8492 25.4558 10
-      vertex -25.4558 14.8492 0
-      vertex -25.4558 14.8492 10
     endloop
   endfacet
   facet normal 0 1 -0
@@ -18815,172 +15791,3154 @@ solid OpenSCAD_Model
       vertex -14.8492 25.4558 0
     endloop
   endfacet
-  facet normal -0.608761 -0.793353 0
+  facet normal 0 0 -1
     outer loop
-      vertex 10 17.3205 0
-      vertex 14.1421 14.1421 10
-      vertex 10 17.3205 10
+      vertex -17.3205 10 0
+      vertex -19.8013 12.7303 0
+      vertex -19.7668 13.0815 0
     endloop
   endfacet
-  facet normal -0.608761 -0.793353 -0
+  facet normal 0 0 -1
     outer loop
-      vertex 14.1421 14.1421 10
+      vertex -17.3205 10 0
+      vertex -19.9038 12.3926 0
+      vertex -19.8013 12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.8395 11.8087 0
+      vertex -19.3185 5.17638 0
+      vertex -20 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -20.0701 12.0814 0
+      vertex -19.9038 12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8779 -11.4185 0
+      vertex -17.3205 -10 0
+      vertex -20.5667 -11.5848 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.3205 -10 0
+      vertex -20.8779 -11.4185 0
+      vertex -19.3185 -5.17638 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -20.294 11.8087 0
+      vertex -20.0701 12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.2156 -11.3161 0
+      vertex -19.3185 -5.17638 0
+      vertex -20.8779 -11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -20.5667 11.5848 0
+      vertex -20.294 11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5668 -11.2815 0
+      vertex -19.3185 -5.17638 0
+      vertex -21.2156 -11.3161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -20.8779 11.4185 0
+      vertex -20.5667 11.5848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9179 -11.3161 0
+      vertex -19.3185 -5.17638 0
+      vertex -21.5668 -11.2815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -21.2156 11.3161 0
+      vertex -20.8779 11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2556 -11.4185 0
+      vertex -19.3185 -5.17638 0
+      vertex -21.9179 -11.3161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -21.5668 11.2815 0
+      vertex -21.2156 11.3161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5668 -11.5848 0
+      vertex -19.3185 -5.17638 0
+      vertex -22.2556 -11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -21.9179 11.3161 0
+      vertex -21.5668 11.2815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.8395 -11.8087 0
+      vertex -19.3185 -5.17638 0
+      vertex -22.5668 -11.5848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -22.2556 11.4185 0
+      vertex -21.9179 11.3161 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.3185 -5.17638 0
+      vertex -22.8395 -11.8087 0
+      vertex -20 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -22.5668 11.5848 0
+      vertex -22.2556 11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0634 -12.0814 0
+      vertex -20 0 0
+      vertex -22.8395 -11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3185 5.17638 0
+      vertex -22.8395 11.8087 0
+      vertex -22.5668 11.5848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -20 0 0
+      vertex -23.0634 -12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20 0 0
+      vertex -23.0634 12.0814 0
+      vertex -22.8395 11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -23.0634 -12.0814 0
+      vertex -23.2297 -12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -20 0 0
+      vertex -25.4558 -14.8492 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -23.2297 -12.3926 0
+      vertex -23.3322 -12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20 0 0
+      vertex -25.4558 14.8492 0
+      vertex -23.0634 12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -23.3322 -12.7303 0
+      vertex -23.3668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0634 12.0814 0
+      vertex -25.4558 14.8492 0
+      vertex -23.2297 12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9038 -12.3926 0
+      vertex -17.3205 -10 0
+      vertex -19.8013 -12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0701 -12.0814 0
+      vertex -17.3205 -10 0
+      vertex -19.9038 -12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.294 -11.8087 0
+      vertex -17.3205 -10 0
+      vertex -20.0701 -12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5667 -11.5848 0
+      vertex -17.3205 -10 0
+      vertex -20.294 -11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 19.3185 0
+      vertex -11.3161 21.2156 0
+      vertex -11.2815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 19.3185 0
+      vertex -11.4185 20.8779 0
+      vertex -11.3161 21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -11.5848 20.5667 0
+      vertex -11.4185 20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -11.8087 20.294 0
+      vertex -11.5848 20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -12.0814 20.0701 0
+      vertex -11.8087 20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -12.3926 19.9038 0
+      vertex -12.0814 20.0701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -12.7303 19.8013 0
+      vertex -12.3926 19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -13.0815 19.7668 0
+      vertex -12.7303 19.8013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4659 17.4655 0
+      vertex -13.0815 19.7668 0
+      vertex -10 17.3205 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -15.4601 17.6418 0
+      vertex -13.0815 19.7668 0
+      vertex -15.4659 17.4655 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.0815 19.7668 0
+      vertex -15.4601 17.6418 0
+      vertex -13.4326 19.8013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.506 17.2936 0
+      vertex -10 17.3205 0
+      vertex -14.1421 14.1421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4889 17.8159 0
+      vertex -13.4326 19.8013 0
+      vertex -15.4601 17.6418 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.4326 19.8013 0
+      vertex -15.4889 17.8159 0
+      vertex -13.7703 19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.6442 18.1308 0
+      vertex -13.7703 19.9038 0
+      vertex -15.551 17.981 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.7703 19.9038 0
+      vertex -15.6442 18.1308 0
+      vertex -14.0815 20.0701 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.0815 20.0701 0
+      vertex -15.7648 18.2596 0
+      vertex -14.3543 20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.7648 18.2596 0
+      vertex -14.0815 20.0701 0
+      vertex -15.6442 18.1308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.551 17.981 0
+      vertex -13.7703 19.9038 0
+      vertex -15.4889 17.8159 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10 17.3205 0
+      vertex -15.506 17.2936 0
+      vertex -15.4659 17.4655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -15.5788 17.1329 0
+      vertex -15.506 17.2936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -15.6815 16.9895 0
+      vertex -15.5788 17.1329 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -16.9895 15.6815 0
+      vertex -15.6815 16.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -17.1329 15.5788 0
+      vertex -16.9895 15.6815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -17.2936 15.506 0
+      vertex -17.1329 15.5788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -17.2936 15.506 0
+      vertex -14.1421 14.1421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3205 10 0
+      vertex -17.4655 15.4659 0
+      vertex -17.2936 15.506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7668 13.0815 0
+      vertex -17.4655 15.4659 0
+      vertex -17.3205 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.4655 15.4659 0
+      vertex -19.7668 13.0815 0
+      vertex -17.6418 15.4601 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8013 13.4326 0
+      vertex -17.6418 15.4601 0
+      vertex -19.7668 13.0815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.6418 15.4601 0
+      vertex -19.8013 13.4326 0
+      vertex -17.8159 15.4889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9038 13.7703 0
+      vertex -17.8159 15.4889 0
+      vertex -19.8013 13.4326 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.8159 15.4889 0
+      vertex -19.9038 13.7703 0
+      vertex -17.981 15.551 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.981 15.551 0
+      vertex -19.9038 13.7703 0
+      vertex -18.1308 15.6442 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0701 14.0815 0
+      vertex -18.1308 15.6442 0
+      vertex -19.9038 13.7703 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.1308 15.6442 0
+      vertex -20.0701 14.0815 0
+      vertex -18.2596 15.7648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8779 11.4185 0
+      vertex -17.3205 10 0
+      vertex -19.3185 5.17638 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.4185 -20.8779 0
+      vertex -5.17638 -19.3185 0
+      vertex -11.3161 -21.2156 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -11.4185 -20.8779 0
+      vertex -10 -17.3205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5848 -20.5667 0
+      vertex -10 -17.3205 0
+      vertex -11.4185 -20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8087 -20.294 0
+      vertex -10 -17.3205 0
+      vertex -11.5848 -20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.0814 -20.0701 0
+      vertex -10 -17.3205 0
+      vertex -11.8087 -20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3926 -19.9038 0
+      vertex -10 -17.3205 0
+      vertex -12.0814 -20.0701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.7303 -19.8013 0
+      vertex -10 -17.3205 0
+      vertex -12.3926 -19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.0815 -19.7668 0
+      vertex -10 -17.3205 0
+      vertex -12.7303 -19.8013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4601 -17.6418 0
+      vertex -13.0815 -19.7668 0
+      vertex -13.4326 -19.8013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4889 -17.8159 0
+      vertex -13.4326 -19.8013 0
+      vertex -13.7703 -19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.6442 -18.1308 0
+      vertex -13.7703 -19.9038 0
+      vertex -14.0815 -20.0701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.0815 -19.7668 0
+      vertex -15.4601 -17.6418 0
+      vertex -15.4659 -17.4655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.7648 -18.2596 0
+      vertex -14.0815 -20.0701 0
+      vertex -14.3543 -20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0689 -18.4352 0
+      vertex -14.3543 -20.294 0
+      vertex -14.5781 -20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0689 -18.4352 0
+      vertex -14.5781 -20.5667 0
+      vertex -14.7445 -20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8556 -18.9139 0
+      vertex -14.7445 -20.8779 0
+      vertex -14.8469 -21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8556 -18.9139 0
+      vertex -14.8469 -21.2156 0
+      vertex -14.8815 -21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.0815 -19.7668 0
+      vertex -15.4659 -17.4655 0
+      vertex -10 -17.3205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.506 -17.2936 0
+      vertex -10 -17.3205 0
+      vertex -15.4659 -17.4655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 -17.3205 0
+      vertex -15.506 -17.2936 0
+      vertex -14.1421 -14.1421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5788 -17.1329 0
+      vertex -14.1421 -14.1421 0
+      vertex -15.506 -17.2936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.6815 -16.9895 0
+      vertex -14.1421 -14.1421 0
+      vertex -15.5788 -17.1329 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.9895 -15.6815 0
+      vertex -14.1421 -14.1421 0
+      vertex -15.6815 -16.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.1329 -15.5788 0
+      vertex -14.1421 -14.1421 0
+      vertex -16.9895 -15.6815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2936 -15.506 0
+      vertex -14.1421 -14.1421 0
+      vertex -17.1329 -15.5788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2936 -15.506 0
+      vertex -17.3205 -10 0
+      vertex -14.1421 -14.1421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.4655 -15.4659 0
+      vertex -17.3205 -10 0
+      vertex -17.2936 -15.506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7668 -13.0815 0
+      vertex -17.4655 -15.4659 0
+      vertex -17.6418 -15.4601 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8013 -13.4326 0
+      vertex -17.6418 -15.4601 0
+      vertex -17.8159 -15.4889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9038 -13.7703 0
+      vertex -17.8159 -15.4889 0
+      vertex -17.981 -15.551 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9038 -13.7703 0
+      vertex -17.981 -15.551 0
+      vertex -18.1308 -15.6442 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0701 -14.0815 0
+      vertex -18.1308 -15.6442 0
+      vertex -18.2596 -15.7648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.294 -14.3543 0
+      vertex -18.2596 -15.7648 0
+      vertex -18.3624 -15.9082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.294 -14.3543 0
+      vertex -18.3624 -15.9082 0
+      vertex -18.4352 -16.0689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8779 -14.7445 0
+      vertex -18.4352 -16.0689 0
+      vertex -18.9139 -17.8556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6418 -15.4601 0
+      vertex -19.8013 -13.4326 0
+      vertex -19.7668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5668 -14.8815 0
+      vertex -18.9139 -17.8556 0
+      vertex -18.9312 -18.0312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5668 14.8815 0
+      vertex 18.9139 17.8556 0
+      vertex 18.9312 18.0312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 18.4352 16.0689 0
+      vertex 18.9139 17.8556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 18.3624 15.9082 0
+      vertex 18.4352 16.0689 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 17.4655 15.4659 0
+      vertex 19.7668 13.0815 0
+      vertex 17.3205 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 18.2596 15.7648 0
+      vertex 18.3624 15.9082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 18.1308 15.6442 0
+      vertex 18.2596 15.7648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 17.981 15.551 0
+      vertex 18.1308 15.6442 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 17.8159 15.4889 0
+      vertex 17.981 15.551 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 17.6418 15.4601 0
+      vertex 17.8159 15.4889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 13.0815 0
+      vertex 17.4655 15.4659 0
+      vertex 17.6418 15.4601 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3205 10 0
+      vertex 17.2936 15.506 0
+      vertex 17.4655 15.4659 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 14.1421 0
+      vertex 17.2936 15.506 0
+      vertex 17.3205 10 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.2936 15.506 0
+      vertex 14.1421 14.1421 0
+      vertex 17.1329 15.5788 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.1329 15.5788 0
+      vertex 14.1421 14.1421 0
+      vertex 16.9895 15.6815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.9895 15.6815 0
+      vertex 14.1421 14.1421 0
+      vertex 15.6815 16.9895 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.6815 16.9895 0
+      vertex 14.1421 14.1421 0
+      vertex 15.5788 17.1329 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.0815 19.7668 0
+      vertex 15.4601 17.6418 0
+      vertex 15.4659 17.4655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 14.8469 21.2156 0
+      vertex 14.8815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 14.7445 20.8779 0
+      vertex 14.8469 21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 14.5781 20.5667 0
+      vertex 14.7445 20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex 10 17.3205 0
+      vertex 15.4659 17.4655 0
+      vertex 15.506 17.2936 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.5788 17.1329 0
+      vertex 14.1421 14.1421 0
+      vertex 15.506 17.2936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 17.3205 0
+      vertex 15.506 17.2936 0
       vertex 14.1421 14.1421 0
     endloop
   endfacet
-  facet normal -0.991445 0.130526 0
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 14.3543 20.294 0
+      vertex 14.5781 20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 14.0815 20.0701 0
+      vertex 14.3543 20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 13.7703 19.9038 0
+      vertex 14.0815 20.0701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 13.4326 19.8013 0
+      vertex 13.7703 19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4601 17.6418 0
+      vertex 13.0815 19.7668 0
+      vertex 13.4326 19.8013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.4659 17.4655 0
+      vertex 10 17.3205 0
+      vertex 13.0815 19.7668 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.0815 19.7668 0
+      vertex 10 17.3205 0
+      vertex 12.7303 19.8013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.7303 19.8013 0
+      vertex 10 17.3205 0
+      vertex 12.3926 19.9038 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.3926 19.9038 0
+      vertex 10 17.3205 0
+      vertex 12.0814 20.0701 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.0814 20.0701 0
+      vertex 10 17.3205 0
+      vertex 11.8087 20.294 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.8087 20.294 0
+      vertex 10 17.3205 0
+      vertex 11.5848 20.5667 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.4185 20.8779 0
+      vertex 5.17638 19.3185 0
+      vertex 11.3161 21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 19.3185 0
+      vertex 11.4185 20.8779 0
+      vertex 10 17.3205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.5848 20.5667 0
+      vertex 10 17.3205 0
+      vertex 11.4185 20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.1308 -15.6442 0
+      vertex 20.0701 -14.0815 0
+      vertex 18.2596 -15.7648 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.0701 -14.0815 0
+      vertex 18.1308 -15.6442 0
+      vertex 19.9038 -13.7703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.981 -15.551 0
+      vertex 19.9038 -13.7703 0
+      vertex 18.1308 -15.6442 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8159 -15.4889 0
+      vertex 19.9038 -13.7703 0
+      vertex 17.981 -15.551 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.9038 -13.7703 0
+      vertex 17.8159 -15.4889 0
+      vertex 19.8013 -13.4326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6418 -15.4601 0
+      vertex 19.8013 -13.4326 0
+      vertex 17.8159 -15.4889 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.8013 -13.4326 0
+      vertex 17.6418 -15.4601 0
+      vertex 19.7668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.4655 -15.4659 0
+      vertex 19.7668 -13.0815 0
+      vertex 17.6418 -15.4601 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.7668 -13.0815 0
+      vertex 17.4655 -15.4659 0
+      vertex 17.3205 -10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7668 -13.0815 0
+      vertex 17.3205 -10 0
+      vertex 19.3185 -5.17638 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2936 -15.506 0
+      vertex 17.3205 -10 0
+      vertex 17.4655 -15.4659 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 17.2936 -15.506 0
+      vertex 17.1329 -15.5788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 17.1329 -15.5788 0
+      vertex 16.9895 -15.6815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 16.9895 -15.6815 0
+      vertex 15.6815 -16.9895 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 15.6815 -16.9895 0
+      vertex 15.5788 -17.1329 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 15.5788 -17.1329 0
+      vertex 15.506 -17.2936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0815 -20.0701 0
+      vertex 15.7648 -18.2596 0
+      vertex 14.3543 -20.294 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.7648 -18.2596 0
+      vertex 14.0815 -20.0701 0
+      vertex 15.6442 -18.1308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.7703 -19.9038 0
+      vertex 15.6442 -18.1308 0
+      vertex 14.0815 -20.0701 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.6442 -18.1308 0
+      vertex 13.7703 -19.9038 0
+      vertex 15.551 -17.981 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.551 -17.981 0
+      vertex 13.7703 -19.9038 0
+      vertex 15.4889 -17.8159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.4326 -19.8013 0
+      vertex 15.4889 -17.8159 0
+      vertex 13.7703 -19.9038 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.4889 -17.8159 0
+      vertex 13.4326 -19.8013 0
+      vertex 15.4601 -17.6418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2936 -15.506 0
+      vertex 14.1421 -14.1421 0
+      vertex 17.3205 -10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.0815 -19.7668 0
+      vertex 15.4601 -17.6418 0
+      vertex 13.4326 -19.8013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.4601 -17.6418 0
+      vertex 13.0815 -19.7668 0
+      vertex 15.4659 -17.4655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 15.4659 -17.4655 0
+      vertex 13.0815 -19.7668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4659 -17.4655 0
+      vertex 10 -17.3205 0
+      vertex 15.506 -17.2936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 13.0815 -19.7668 0
+      vertex 12.7303 -19.8013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 12.7303 -19.8013 0
+      vertex 12.3926 -19.9038 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 12.3926 -19.9038 0
+      vertex 12.0814 -20.0701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 12.0814 -20.0701 0
+      vertex 11.8087 -20.294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 11.8087 -20.294 0
+      vertex 11.5848 -20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 11.5848 -20.5667 0
+      vertex 11.4185 -20.8779 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.506 -17.2936 0
+      vertex 10 -17.3205 0
+      vertex 14.1421 -14.1421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 -19.3185 0
+      vertex 11.4185 -20.8779 0
+      vertex 11.3161 -21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 -19.3185 0
+      vertex 11.3161 -21.2156 0
+      vertex 11.2815 -21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0634 -12.0814 0
+      vertex 25.4558 -14.8492 0
+      vertex 23.2297 -12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 14.8492 0
+      vertex 23.3322 12.7303 0
+      vertex 23.3668 13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20 0 0
+      vertex 25.4558 -14.8492 0
+      vertex 23.0634 -12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 14.8492 0
+      vertex 23.2297 12.3926 0
+      vertex 23.3322 12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 20 0 0
+      vertex 25.4558 14.8492 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 14.8492 0
+      vertex 23.0634 12.0814 0
+      vertex 23.2297 12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20 0 0
+      vertex 23.0634 -12.0814 0
+      vertex 22.8395 -11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 14.8492 0
+      vertex 20 0 0
+      vertex 23.0634 12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
     outer loop
       vertex 19.3185 -5.17638 0
-      vertex 20 0 10
+      vertex 22.8395 -11.8087 0
+      vertex 22.5668 -11.5848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0634 12.0814 0
+      vertex 20 0 0
+      vertex 22.8395 11.8087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 22.5668 -11.5848 0
+      vertex 22.2556 -11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 5.17638 0
+      vertex 22.8395 11.8087 0
       vertex 20 0 0
     endloop
   endfacet
-  facet normal -0.991445 0.130526 0
+  facet normal 0 0 -1
     outer loop
-      vertex 20 0 10
       vertex 19.3185 -5.17638 0
-      vertex 19.3185 -5.17638 10
+      vertex 22.2556 -11.4185 0
+      vertex 21.9179 -11.3161 0
     endloop
   endfacet
-  facet normal 0.382683 0.92388 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -5.17638 -19.3185 0
-      vertex -10 -17.3205 10
-      vertex -5.17638 -19.3185 10
-    endloop
-  endfacet
-  facet normal 0.382683 0.92388 0
-    outer loop
-      vertex -10 -17.3205 10
-      vertex -5.17638 -19.3185 0
-      vertex -10 -17.3205 0
-    endloop
-  endfacet
-  facet normal -0.793354 -0.608761 0
-    outer loop
-      vertex 17.3205 10 0
-      vertex 14.1421 14.1421 10
-      vertex 14.1421 14.1421 0
-    endloop
-  endfacet
-  facet normal -0.793354 -0.608761 0
-    outer loop
-      vertex 14.1421 14.1421 10
-      vertex 17.3205 10 0
-      vertex 17.3205 10 10
-    endloop
-  endfacet
-  facet normal -0.92388 -0.382683 0
-    outer loop
+      vertex 22.8395 11.8087 0
       vertex 19.3185 5.17638 0
-      vertex 17.3205 10 10
-      vertex 17.3205 10 0
+      vertex 22.5668 11.5848 0
     endloop
   endfacet
-  facet normal -0.92388 -0.382683 0
+  facet normal 0 0 -1
     outer loop
-      vertex 17.3205 10 10
+      vertex 19.3185 -5.17638 0
+      vertex 21.9179 -11.3161 0
+      vertex 21.5668 -11.2815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5668 11.5848 0
       vertex 19.3185 5.17638 0
-      vertex 19.3185 5.17638 10
+      vertex 22.2556 11.4185 0
     endloop
   endfacet
-  facet normal 0.382683 -0.92388 0
+  facet normal 0 0 -1
     outer loop
-      vertex -10 17.3205 0
-      vertex -5.17638 19.3185 10
-      vertex -10 17.3205 10
+      vertex 19.3185 -5.17638 0
+      vertex 21.5668 -11.2815 0
+      vertex 21.2156 -11.3161 0
     endloop
   endfacet
-  facet normal 0.382683 -0.92388 0
+  facet normal 0 0 -1
     outer loop
-      vertex -5.17638 19.3185 10
-      vertex -10 17.3205 0
-      vertex -5.17638 19.3185 0
+      vertex 22.2556 11.4185 0
+      vertex 19.3185 5.17638 0
+      vertex 21.9179 11.3161 0
     endloop
   endfacet
-  facet normal 0.608761 -0.793354 0
+  facet normal 0 0 -1
     outer loop
-      vertex -14.1421 14.1421 0
-      vertex -10 17.3205 10
-      vertex -14.1421 14.1421 10
+      vertex 19.3185 -5.17638 0
+      vertex 21.2156 -11.3161 0
+      vertex 20.8779 -11.4185 0
     endloop
   endfacet
-  facet normal 0.608761 -0.793354 0
+  facet normal 0 0 -1
     outer loop
-      vertex -10 17.3205 10
-      vertex -14.1421 14.1421 0
-      vertex -10 17.3205 0
+      vertex 21.9179 11.3161 0
+      vertex 19.3185 5.17638 0
+      vertex 21.5668 11.2815 0
     endloop
   endfacet
-  facet normal -0.608761 0.793353 0
+  facet normal 0 0 -1
     outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 10 -17.3205 10
-      vertex 14.1421 -14.1421 10
+      vertex 19.3185 -5.17638 0
+      vertex 20.8779 -11.4185 0
+      vertex 20.5667 -11.5848 0
     endloop
   endfacet
-  facet normal -0.608761 0.793353 0
+  facet normal -0 0 -1
     outer loop
-      vertex 10 -17.3205 10
-      vertex 14.1421 -14.1421 0
+      vertex 21.5668 11.2815 0
+      vertex 19.3185 5.17638 0
+      vertex 21.2156 11.3161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 20.5667 -11.5848 0
+      vertex 20.294 -11.8087 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.2156 11.3161 0
+      vertex 19.3185 5.17638 0
+      vertex 20.8779 11.4185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 20.294 -11.8087 0
+      vertex 20.0701 -12.0814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3205 10 0
+      vertex 20.8779 11.4185 0
+      vertex 19.3185 5.17638 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.8779 11.4185 0
+      vertex 17.3205 10 0
+      vertex 20.5667 11.5848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 20.0701 -12.0814 0
+      vertex 19.9038 -12.3926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 19.9038 -12.3926 0
+      vertex 19.8013 -12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 19.8013 -12.7303 0
+      vertex 19.7668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.8395 -11.8087 0
+      vertex 19.3185 -5.17638 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.3322 -12.7303 0
+      vertex 25.4558 -14.8492 0
+      vertex 23.3668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 23.3322 -13.4326 0
+      vertex 23.3668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 23.2297 -13.7703 0
+      vertex 23.3322 -13.4326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 23.0634 -14.0815 0
+      vertex 23.2297 -13.7703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 22.8395 -14.3543 0
+      vertex 23.0634 -14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 22.5668 -14.5781 0
+      vertex 22.8395 -14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 22.2556 -14.7445 0
+      vertex 22.5668 -14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 -18.2068 0
+      vertex 22.2556 -14.7445 0
+      vertex 25.4558 -14.8492 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.2556 -14.7445 0
+      vertex 18.9139 -18.2068 0
+      vertex 21.9179 -14.8469 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.294 -14.3543 0
+      vertex 18.2596 -15.7648 0
+      vertex 20.0701 -14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2596 -15.7648 0
+      vertex 20.294 -14.3543 0
+      vertex 18.3624 -15.9082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3624 -15.9082 0
+      vertex 20.294 -14.3543 0
+      vertex 18.4352 -16.0689 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5667 -14.5781 0
+      vertex 18.4352 -16.0689 0
+      vertex 20.294 -14.3543 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.8779 -14.7445 0
+      vertex 18.4352 -16.0689 0
+      vertex 20.5667 -14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.4352 -16.0689 0
+      vertex 20.8779 -14.7445 0
+      vertex 18.9139 -17.8556 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.2156 -14.8469 0
+      vertex 18.9139 -17.8556 0
+      vertex 20.8779 -14.7445 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.5668 -14.8815 0
+      vertex 18.9139 -17.8556 0
+      vertex 21.2156 -14.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 -17.8556 0
+      vertex 21.5668 -14.8815 0
+      vertex 18.9312 -18.0312 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 18.9312 -18.0312 0
+      vertex 21.9179 -14.8469 0
+      vertex 18.9139 -18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.9179 -14.8469 0
+      vertex 18.9312 -18.0312 0
+      vertex 21.5668 -14.8815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 18.8627 -18.3756 0
+      vertex 18.9139 -18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 18.7795 -18.5312 0
+      vertex 18.8627 -18.3756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4558 -14.8492 0
+      vertex 18.6676 -18.6676 0
+      vertex 18.7795 -18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 18.6676 -18.6676 0
+      vertex 25.4558 -14.8492 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.9082 -18.3624 0
+      vertex 14.3543 -20.294 0
+      vertex 15.7648 -18.2596 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.0689 -18.4352 0
+      vertex 14.3543 -20.294 0
+      vertex 15.9082 -18.3624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3543 -20.294 0
+      vertex 16.0689 -18.4352 0
+      vertex 14.5781 -20.5667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5781 -20.5667 0
+      vertex 16.0689 -18.4352 0
+      vertex 14.7445 -20.8779 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.8556 -18.9139 0
+      vertex 14.7445 -20.8779 0
+      vertex 16.0689 -18.4352 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7445 -20.8779 0
+      vertex 17.8556 -18.9139 0
+      vertex 14.8469 -21.2156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8469 -21.2156 0
+      vertex 17.8556 -18.9139 0
+      vertex 14.8815 -21.5668 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.0312 -18.9312 0
+      vertex 14.8815 -21.5668 0
+      vertex 17.8556 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8469 -21.9179 0
+      vertex 18.0312 -18.9312 0
+      vertex 18.2068 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 18.2068 -18.9139 0
+      vertex 18.3756 -18.8627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 18.3756 -18.8627 0
+      vertex 18.5312 -18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6676 -18.6676 0
+      vertex 14.8492 -25.4558 0
+      vertex 18.5312 -18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2068 -18.9139 0
+      vertex 14.8492 -25.4558 0
+      vertex 14.7445 -22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0312 -18.9312 0
+      vertex 14.8469 -21.9179 0
+      vertex 14.8815 -21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2068 -18.9139 0
+      vertex 14.7445 -22.2556 0
+      vertex 14.8469 -21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 14.5781 -22.5668 0
+      vertex 14.7445 -22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 14.3543 -22.8395 0
+      vertex 14.5781 -22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 14.0815 -23.0634 0
+      vertex 14.3543 -22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 13.7703 -23.2297 0
+      vertex 14.0815 -23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 13.4326 -23.3322 0
+      vertex 13.7703 -23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 13.0815 -23.3668 0
+      vertex 13.4326 -23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 12.7303 -23.3322 0
+      vertex 13.0815 -23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 12.3926 -23.2297 0
+      vertex 12.7303 -23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 -25.4558 0
+      vertex 12.0814 -23.0634 0
+      vertex 12.3926 -23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -20 0
+      vertex 12.0814 -23.0634 0
+      vertex 14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 -19.3185 0
+      vertex 11.2815 -21.5668 0
+      vertex 11.3161 -21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4185 -20.8779 0
+      vertex 5.17638 -19.3185 0
       vertex 10 -17.3205 0
     endloop
   endfacet
-  facet normal 0.92388 0.382683 0
+  facet normal 0 0 -1
     outer loop
-      vertex -17.3205 -10 10
-      vertex -19.3185 -5.17638 0
-      vertex -19.3185 -5.17638 10
+      vertex 11.4185 -22.2556 0
+      vertex 5.17638 -19.3185 0
+      vertex 11.3161 -21.9179 0
     endloop
   endfacet
-  facet normal 0.92388 0.382683 0
+  facet normal 0 0 -1
     outer loop
-      vertex -19.3185 -5.17638 0
-      vertex -17.3205 -10 10
+      vertex 11.5848 -22.5668 0
+      vertex 5.17638 -19.3185 0
+      vertex 11.4185 -22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.8087 -22.8395 0
+      vertex 5.17638 -19.3185 0
+      vertex 11.5848 -22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.0814 -23.0634 0
+      vertex 0 -20 0
+      vertex 11.8087 -22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.8087 -22.8395 0
+      vertex 0 -20 0
+      vertex 5.17638 -19.3185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex 0 -20 0
+      vertex 14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.3161 -21.2156 0
+      vertex -5.17638 -19.3185 0
+      vertex -11.2815 -21.5668 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0 -20 0
+      vertex -11.8087 -22.8395 0
+      vertex -5.17638 -19.3185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -11.3161 -21.9179 0
+      vertex -11.2815 -21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -11.4185 -22.2556 0
+      vertex -11.3161 -21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -11.5848 -22.5668 0
+      vertex -11.4185 -22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -11.8087 -22.8395 0
+      vertex -11.5848 -22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -20 0
+      vertex -12.0814 -23.0634 0
+      vertex -11.8087 -22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -20 0
+      vertex -14.8492 -25.4558 0
+      vertex -12.0814 -23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.0814 -23.0634 0
+      vertex -14.8492 -25.4558 0
+      vertex -12.3926 -23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3926 -23.2297 0
+      vertex -14.8492 -25.4558 0
+      vertex -12.7303 -23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.7303 -23.3322 0
+      vertex -14.8492 -25.4558 0
+      vertex -13.0815 -23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -13.4326 -23.3322 0
+      vertex -13.0815 -23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -13.7703 -23.2297 0
+      vertex -13.4326 -23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -14.0815 -23.0634 0
+      vertex -13.7703 -23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -14.3543 -22.8395 0
+      vertex -14.0815 -23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -14.5781 -22.5668 0
+      vertex -14.3543 -22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -14.7445 -22.2556 0
+      vertex -14.5781 -22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2068 -18.9139 0
+      vertex -14.7445 -22.2556 0
+      vertex -14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7445 -22.2556 0
+      vertex -18.2068 -18.9139 0
+      vertex -14.8469 -21.9179 0
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex -18.0312 -18.9312 0
+      vertex -14.8469 -21.9179 0
+      vertex -18.2068 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4326 -19.8013 0
+      vertex -15.4889 -17.8159 0
+      vertex -15.4601 -17.6418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.7703 -19.9038 0
+      vertex -15.551 -17.981 0
+      vertex -15.4889 -17.8159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.7703 -19.9038 0
+      vertex -15.6442 -18.1308 0
+      vertex -15.551 -17.981 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0815 -20.0701 0
+      vertex -15.7648 -18.2596 0
+      vertex -15.6442 -18.1308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3543 -20.294 0
+      vertex -15.9082 -18.3624 0
+      vertex -15.7648 -18.2596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3543 -20.294 0
+      vertex -16.0689 -18.4352 0
+      vertex -15.9082 -18.3624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7445 -20.8779 0
+      vertex -17.8556 -18.9139 0
+      vertex -16.0689 -18.4352 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8815 -21.5668 0
+      vertex -18.0312 -18.9312 0
+      vertex -17.8556 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8469 -21.9179 0
+      vertex -18.0312 -18.9312 0
+      vertex -14.8815 -21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -18.3756 -18.8627 0
+      vertex -18.2068 -18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -18.5312 -18.7795 0
+      vertex -18.3756 -18.8627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -18.6676 -18.6676 0
+      vertex -18.5312 -18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -18.6676 -18.6676 0
+      vertex -14.8492 -25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8013 -12.7303 0
+      vertex -17.3205 -10 0
+      vertex -19.7668 -13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9179 -14.8469 0
+      vertex -18.9312 -18.0312 0
+      vertex -18.9139 -18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.4655 -15.4659 0
+      vertex -19.7668 -13.0815 0
       vertex -17.3205 -10 0
     endloop
   endfacet
-  facet normal 0.608761 0.793353 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -10 -17.3205 0
-      vertex -14.1421 -14.1421 10
-      vertex -10 -17.3205 10
+      vertex -17.8159 -15.4889 0
+      vertex -19.9038 -13.7703 0
+      vertex -19.8013 -13.4326 0
     endloop
   endfacet
-  facet normal 0.608761 0.793353 0
+  facet normal 0 0 -1
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -10 -17.3205 0
-      vertex -14.1421 -14.1421 0
+      vertex -18.1308 -15.6442 0
+      vertex -20.0701 -14.0815 0
+      vertex -19.9038 -13.7703 0
     endloop
   endfacet
-  facet normal 0.793354 0.608761 0
+  facet normal 0 0 -1
     outer loop
-      vertex -14.1421 -14.1421 10
-      vertex -17.3205 -10 0
-      vertex -17.3205 -10 10
+      vertex -18.2596 -15.7648 0
+      vertex -20.294 -14.3543 0
+      vertex -20.0701 -14.0815 0
     endloop
   endfacet
-  facet normal 0.793354 0.608761 0
+  facet normal 0 0 -1
     outer loop
-      vertex -17.3205 -10 0
-      vertex -14.1421 -14.1421 10
-      vertex -14.1421 -14.1421 0
+      vertex -25.4558 -14.8492 0
+      vertex -18.9139 -18.2068 0
+      vertex -18.8627 -18.3756 0
     endloop
   endfacet
-  facet normal -0.130526 -0.991445 0
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4352 -16.0689 0
+      vertex -20.5667 -14.5781 0
+      vertex -20.294 -14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4352 -16.0689 0
+      vertex -20.8779 -14.7445 0
+      vertex -20.5667 -14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 -14.8492 0
+      vertex -18.8627 -18.3756 0
+      vertex -18.7795 -18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9139 -17.8556 0
+      vertex -21.2156 -14.8469 0
+      vertex -20.8779 -14.7445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6676 -18.6676 0
+      vertex -25.4558 -14.8492 0
+      vertex -18.7795 -18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9139 -17.8556 0
+      vertex -21.5668 -14.8815 0
+      vertex -21.2156 -14.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9312 -18.0312 0
+      vertex -21.9179 -14.8469 0
+      vertex -21.5668 -14.8815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9139 -18.2068 0
+      vertex -25.4558 -14.8492 0
+      vertex -22.2556 -14.7445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9139 -18.2068 0
+      vertex -22.2556 -14.7445 0
+      vertex -21.9179 -14.8469 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.2556 -14.7445 0
+      vertex -25.4558 -14.8492 0
+      vertex -22.5668 -14.5781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.5668 -14.5781 0
+      vertex -25.4558 -14.8492 0
+      vertex -22.8395 -14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2297 12.3926 0
+      vertex -25.4558 14.8492 0
+      vertex -23.3322 12.7303 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.3322 -13.4326 0
+      vertex -25.4558 -14.8492 0
+      vertex -23.3668 -13.0815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.2297 -13.7703 0
+      vertex -25.4558 -14.8492 0
+      vertex -23.3322 -13.4326 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.0634 -14.0815 0
+      vertex -25.4558 -14.8492 0
+      vertex -23.2297 -13.7703 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.8395 -14.3543 0
+      vertex -25.4558 -14.8492 0
+      vertex -23.0634 -14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.2297 -12.3926 0
+      vertex 25.4558 -14.8492 0
+      vertex 23.3322 -12.7303 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.3322 13.4326 0
+      vertex 25.4558 14.8492 0
+      vertex 23.3668 13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.2297 13.7703 0
+      vertex 25.4558 14.8492 0
+      vertex 23.3322 13.4326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0634 14.0815 0
+      vertex 25.4558 14.8492 0
+      vertex 23.2297 13.7703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.8395 14.3543 0
+      vertex 25.4558 14.8492 0
+      vertex 23.0634 14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5668 14.5781 0
+      vertex 25.4558 14.8492 0
+      vertex 22.8395 14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.2556 14.7445 0
+      vertex 25.4558 14.8492 0
+      vertex 22.5668 14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 18.2068 0
+      vertex 22.2556 14.7445 0
+      vertex 21.9179 14.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9312 18.0312 0
+      vertex 21.9179 14.8469 0
+      vertex 21.5668 14.8815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.8013 12.7303 0
+      vertex 17.3205 10 0
+      vertex 19.7668 13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 19.8013 13.4326 0
+      vertex 19.7668 13.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 19.9038 13.7703 0
+      vertex 19.8013 13.4326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 20.0701 14.0815 0
+      vertex 19.9038 13.7703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 20.294 14.3543 0
+      vertex 20.0701 14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 20.5667 14.5781 0
+      vertex 20.294 14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 20.8779 14.7445 0
+      vertex 20.5667 14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 21.2156 14.8469 0
+      vertex 20.8779 14.7445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9139 17.8556 0
+      vertex 21.5668 14.8815 0
+      vertex 21.2156 14.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.9179 14.8469 0
+      vertex 18.9312 18.0312 0
+      vertex 18.9139 18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.2556 14.7445 0
+      vertex 18.9139 18.2068 0
+      vertex 25.4558 14.8492 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.8627 18.3756 0
+      vertex 25.4558 14.8492 0
+      vertex 18.9139 18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.7795 18.5312 0
+      vertex 25.4558 14.8492 0
+      vertex 18.8627 18.3756 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6676 18.6676 0
+      vertex 25.4558 14.8492 0
+      vertex 18.7795 18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8492 25.4558 0
+      vertex 18.6676 18.6676 0
+      vertex 18.5312 18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 15.4889 17.8159 0
+      vertex 15.4601 17.6418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 15.551 17.981 0
+      vertex 15.4889 17.8159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 15.6442 18.1308 0
+      vertex 15.551 17.981 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 15.7648 18.2596 0
+      vertex 15.6442 18.1308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 15.9082 18.3624 0
+      vertex 15.7648 18.2596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 16.0689 18.4352 0
+      vertex 15.9082 18.3624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 17.8556 18.9139 0
+      vertex 16.0689 18.4352 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8815 21.5668 0
+      vertex 18.0312 18.9312 0
+      vertex 17.8556 18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8469 21.9179 0
+      vertex 18.0312 18.9312 0
+      vertex 14.8815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0312 18.9312 0
+      vertex 14.8469 21.9179 0
+      vertex 18.2068 18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7445 22.2556 0
+      vertex 18.2068 18.9139 0
+      vertex 14.8469 21.9179 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 14.8492 25.4558 0
+      vertex 18.2068 18.9139 0
+      vertex 14.7445 22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2068 18.9139 0
+      vertex 14.8492 25.4558 0
+      vertex 18.3756 18.8627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6676 18.6676 0
+      vertex 14.8492 25.4558 0
+      vertex 25.4558 14.8492 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3756 18.8627 0
+      vertex 14.8492 25.4558 0
+      vertex 18.5312 18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5781 22.5668 0
+      vertex 14.8492 25.4558 0
+      vertex 14.7445 22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3543 22.8395 0
+      vertex 14.8492 25.4558 0
+      vertex 14.5781 22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0815 23.0634 0
+      vertex 14.8492 25.4558 0
+      vertex 14.3543 22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.7703 23.2297 0
+      vertex 14.8492 25.4558 0
+      vertex 14.0815 23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.4326 23.3322 0
+      vertex 14.8492 25.4558 0
+      vertex 13.7703 23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.0815 23.3668 0
+      vertex 14.8492 25.4558 0
+      vertex 13.4326 23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.7303 23.3322 0
+      vertex 14.8492 25.4558 0
+      vertex 13.0815 23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3926 23.2297 0
+      vertex 14.8492 25.4558 0
+      vertex 12.7303 23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.0814 23.0634 0
+      vertex 14.8492 25.4558 0
+      vertex 12.3926 23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
     outer loop
       vertex 0 20 0
-      vertex 5.17638 19.3185 10
-      vertex 0 20 10
+      vertex 12.0814 23.0634 0
+      vertex 11.8087 22.8395 0
     endloop
   endfacet
-  facet normal -0.130526 -0.991445 -0
+  facet normal -0 0 -1
     outer loop
-      vertex 5.17638 19.3185 10
-      vertex 0 20 0
+      vertex 11.3161 21.2156 0
       vertex 5.17638 19.3185 0
+      vertex 11.2815 21.5668 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.2815 21.5668 0
+      vertex 5.17638 19.3185 0
+      vertex 11.3161 21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 19.3185 0
+      vertex 11.4185 22.2556 0
+      vertex 11.3161 21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 19.3185 0
+      vertex 11.5848 22.5668 0
+      vertex 11.4185 22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.17638 19.3185 0
+      vertex 11.8087 22.8395 0
+      vertex 11.5848 22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 20 0
+      vertex 11.8087 22.8395 0
+      vertex 5.17638 19.3185 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.0814 23.0634 0
+      vertex 0 20 0
+      vertex 14.8492 25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8087 22.8395 0
+      vertex 0 20 0
+      vertex -5.17638 19.3185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.4185 20.8779 0
+      vertex -5.17638 19.3185 0
+      vertex -10 17.3205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.3161 21.9179 0
+      vertex -5.17638 19.3185 0
+      vertex -11.2815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.4185 22.2556 0
+      vertex -5.17638 19.3185 0
+      vertex -11.3161 21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5848 22.5668 0
+      vertex -5.17638 19.3185 0
+      vertex -11.4185 22.2556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8087 22.8395 0
+      vertex -5.17638 19.3185 0
+      vertex -11.5848 22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.0814 23.0634 0
+      vertex 0 20 0
+      vertex -11.8087 22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 25.4558 0
+      vertex 0 20 0
+      vertex -12.0814 23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 25.4558 0
+      vertex -12.0814 23.0634 0
+      vertex -12.3926 23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 25.4558 0
+      vertex -12.3926 23.2297 0
+      vertex -12.7303 23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8492 25.4558 0
+      vertex -12.7303 23.3322 0
+      vertex -13.0815 23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 20 0
+      vertex -14.8492 25.4558 0
+      vertex 14.8492 25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4326 23.3322 0
+      vertex -14.8492 25.4558 0
+      vertex -13.0815 23.3668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.7703 23.2297 0
+      vertex -14.8492 25.4558 0
+      vertex -13.4326 23.3322 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0815 23.0634 0
+      vertex -14.8492 25.4558 0
+      vertex -13.7703 23.2297 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3543 22.8395 0
+      vertex -14.8492 25.4558 0
+      vertex -14.0815 23.0634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5781 22.5668 0
+      vertex -14.8492 25.4558 0
+      vertex -14.3543 22.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7445 22.2556 0
+      vertex -14.8492 25.4558 0
+      vertex -14.5781 22.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2068 18.9139 0
+      vertex -14.7445 22.2556 0
+      vertex -14.8469 21.9179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0312 18.9312 0
+      vertex -14.8469 21.9179 0
+      vertex -14.8815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9082 18.3624 0
+      vertex -14.3543 20.294 0
+      vertex -15.7648 18.2596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0689 18.4352 0
+      vertex -14.3543 20.294 0
+      vertex -15.9082 18.3624 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.3543 20.294 0
+      vertex -16.0689 18.4352 0
+      vertex -14.5781 20.5667 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.5781 20.5667 0
+      vertex -16.0689 18.4352 0
+      vertex -14.7445 20.8779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.8556 18.9139 0
+      vertex -14.7445 20.8779 0
+      vertex -16.0689 18.4352 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.7445 20.8779 0
+      vertex -17.8556 18.9139 0
+      vertex -14.8469 21.2156 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.8469 21.2156 0
+      vertex -17.8556 18.9139 0
+      vertex -14.8815 21.5668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0312 18.9312 0
+      vertex -14.8815 21.5668 0
+      vertex -17.8556 18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8469 21.9179 0
+      vertex -18.0312 18.9312 0
+      vertex -18.2068 18.9139 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.7445 22.2556 0
+      vertex -18.2068 18.9139 0
+      vertex -14.8492 25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3756 18.8627 0
+      vertex -14.8492 25.4558 0
+      vertex -18.2068 18.9139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5312 18.7795 0
+      vertex -14.8492 25.4558 0
+      vertex -18.3756 18.8627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6676 18.6676 0
+      vertex -14.8492 25.4558 0
+      vertex -18.5312 18.7795 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -18.6676 18.6676 0
+      vertex -18.7795 18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.294 14.3543 0
+      vertex -18.2596 15.7648 0
+      vertex -20.0701 14.0815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.2596 15.7648 0
+      vertex -20.294 14.3543 0
+      vertex -18.3624 15.9082 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.3624 15.9082 0
+      vertex -20.294 14.3543 0
+      vertex -18.4352 16.0689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5667 14.5781 0
+      vertex -18.4352 16.0689 0
+      vertex -20.294 14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8779 14.7445 0
+      vertex -18.4352 16.0689 0
+      vertex -20.5667 14.5781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.4352 16.0689 0
+      vertex -20.8779 14.7445 0
+      vertex -18.9139 17.8556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.2156 14.8469 0
+      vertex -18.9139 17.8556 0
+      vertex -20.8779 14.7445 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5668 14.8815 0
+      vertex -18.9139 17.8556 0
+      vertex -21.2156 14.8469 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9139 17.8556 0
+      vertex -21.5668 14.8815 0
+      vertex -18.9312 18.0312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9179 14.8469 0
+      vertex -18.9312 18.0312 0
+      vertex -21.5668 14.8815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9312 18.0312 0
+      vertex -21.9179 14.8469 0
+      vertex -18.9139 18.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2556 14.7445 0
+      vertex -18.9139 18.2068 0
+      vertex -21.9179 14.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -18.9139 18.2068 0
+      vertex -22.2556 14.7445 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9139 18.2068 0
+      vertex -25.4558 14.8492 0
+      vertex -18.8627 18.3756 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.8627 18.3756 0
+      vertex -25.4558 14.8492 0
+      vertex -18.7795 18.5312 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -22.2556 14.7445 0
+      vertex -22.5668 14.5781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -22.5668 14.5781 0
+      vertex -22.8395 14.3543 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4558 14.8492 0
+      vertex -22.8395 14.3543 0
+      vertex -23.0634 14.0815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.6676 18.6676 0
+      vertex -25.4558 14.8492 0
+      vertex -14.8492 25.4558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2297 13.7703 0
+      vertex -25.4558 14.8492 0
+      vertex -23.0634 14.0815 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.3322 13.4326 0
+      vertex -25.4558 14.8492 0
+      vertex -23.2297 13.7703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.3668 13.0815 0
+      vertex -25.4558 14.8492 0
+      vertex -23.3322 13.4326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.3322 12.7303 0
+      vertex -25.4558 14.8492 0
+      vertex -23.3668 13.0815 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5667 11.5848 0
+      vertex 17.3205 10 0
+      vertex 20.294 11.8087 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.294 11.8087 0
+      vertex 17.3205 10 0
+      vertex 20.0701 12.0814 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.0701 12.0814 0
+      vertex 17.3205 10 0
+      vertex 19.9038 12.3926 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.9038 12.3926 0
+      vertex 17.3205 10 0
+      vertex 19.8013 12.7303 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -14.8492 -25.4558 0
+      vertex -25.4558 -14.8492 10
+      vertex -25.4558 -14.8492 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -25.4558 -14.8492 10
+      vertex -14.8492 -25.4558 0
+      vertex -14.8492 -25.4558 10
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 25.4558 14.8492 10
+      vertex 14.8492 25.4558 0
+      vertex 14.8492 25.4558 10
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 14.8492 25.4558 0
+      vertex 25.4558 14.8492 10
+      vertex 25.4558 14.8492 0
+    endloop
+  endfacet
+  facet normal -0.991445 -0.130526 0
+    outer loop
+      vertex 20 0 0
+      vertex 19.3185 5.17638 10
+      vertex 19.3185 5.17638 0
+    endloop
+  endfacet
+  facet normal -0.991445 -0.130526 0
+    outer loop
+      vertex 19.3185 5.17638 10
+      vertex 20 0 0
+      vertex 20 0 10
     endloop
   endfacet
   facet normal 0.991445 -0.130526 0
@@ -18997,102 +18955,18 @@ solid OpenSCAD_Model
       vertex -20 0 0
     endloop
   endfacet
-  facet normal 0.793354 -0.608761 0
+  facet normal -0.130526 -0.991445 0
     outer loop
-      vertex -17.3205 10 10
-      vertex -14.1421 14.1421 0
-      vertex -14.1421 14.1421 10
-    endloop
-  endfacet
-  facet normal 0.793354 -0.608761 0
-    outer loop
-      vertex -14.1421 14.1421 0
-      vertex -17.3205 10 10
-      vertex -17.3205 10 0
-    endloop
-  endfacet
-  facet normal 0.130526 -0.991445 0
-    outer loop
-      vertex -5.17638 19.3185 0
-      vertex 0 20 10
-      vertex -5.17638 19.3185 10
-    endloop
-  endfacet
-  facet normal 0.130526 -0.991445 0
-    outer loop
-      vertex 0 20 10
-      vertex -5.17638 19.3185 0
       vertex 0 20 0
+      vertex 5.17638 19.3185 10
+      vertex 0 20 10
     endloop
   endfacet
-  facet normal -0.991445 -0.130526 0
+  facet normal -0.130526 -0.991445 -0
     outer loop
-      vertex 20 0 0
-      vertex 19.3185 5.17638 10
-      vertex 19.3185 5.17638 0
-    endloop
-  endfacet
-  facet normal -0.991445 -0.130526 0
-    outer loop
-      vertex 19.3185 5.17638 10
-      vertex 20 0 0
-      vertex 20 0 10
-    endloop
-  endfacet
-  facet normal -0.130526 0.991445 0
-    outer loop
-      vertex 5.17638 -19.3185 0
-      vertex 0 -20 10
-      vertex 5.17638 -19.3185 10
-    endloop
-  endfacet
-  facet normal -0.130526 0.991445 0
-    outer loop
-      vertex 0 -20 10
-      vertex 5.17638 -19.3185 0
-      vertex 0 -20 0
-    endloop
-  endfacet
-  facet normal -0.793353 0.608761 0
-    outer loop
-      vertex 14.1421 -14.1421 0
-      vertex 17.3205 -10 10
-      vertex 17.3205 -10 0
-    endloop
-  endfacet
-  facet normal -0.793353 0.608761 0
-    outer loop
-      vertex 17.3205 -10 10
-      vertex 14.1421 -14.1421 0
-      vertex 14.1421 -14.1421 10
-    endloop
-  endfacet
-  facet normal -0.92388 0.382683 0
-    outer loop
-      vertex 17.3205 -10 0
-      vertex 19.3185 -5.17638 10
-      vertex 19.3185 -5.17638 0
-    endloop
-  endfacet
-  facet normal -0.92388 0.382683 0
-    outer loop
-      vertex 19.3185 -5.17638 10
-      vertex 17.3205 -10 0
-      vertex 17.3205 -10 10
-    endloop
-  endfacet
-  facet normal -0.382683 0.92388 0
-    outer loop
-      vertex 10 -17.3205 0
-      vertex 5.17638 -19.3185 10
-      vertex 10 -17.3205 10
-    endloop
-  endfacet
-  facet normal -0.382683 0.92388 0
-    outer loop
-      vertex 5.17638 -19.3185 10
-      vertex 10 -17.3205 0
-      vertex 5.17638 -19.3185 0
+      vertex 5.17638 19.3185 10
+      vertex 0 20 0
+      vertex 5.17638 19.3185 0
     endloop
   endfacet
   facet normal 0.130526 0.991445 -0
@@ -19109,18 +18983,102 @@ solid OpenSCAD_Model
       vertex -5.17638 -19.3185 0
     endloop
   endfacet
-  facet normal 0.991445 0.130526 0
+  facet normal -0.793354 -0.608761 0
     outer loop
-      vertex -19.3185 -5.17638 10
-      vertex -20 0 0
-      vertex -20 0 10
+      vertex 17.3205 10 0
+      vertex 14.1421 14.1421 10
+      vertex 14.1421 14.1421 0
     endloop
   endfacet
-  facet normal 0.991445 0.130526 0
+  facet normal -0.793354 -0.608761 0
     outer loop
-      vertex -20 0 0
-      vertex -19.3185 -5.17638 10
-      vertex -19.3185 -5.17638 0
+      vertex 14.1421 14.1421 10
+      vertex 17.3205 10 0
+      vertex 17.3205 10 10
+    endloop
+  endfacet
+  facet normal -0.92388 -0.382683 0
+    outer loop
+      vertex 19.3185 5.17638 0
+      vertex 17.3205 10 10
+      vertex 17.3205 10 0
+    endloop
+  endfacet
+  facet normal -0.92388 -0.382683 0
+    outer loop
+      vertex 17.3205 10 10
+      vertex 19.3185 5.17638 0
+      vertex 19.3185 5.17638 10
+    endloop
+  endfacet
+  facet normal -0.608761 -0.793353 0
+    outer loop
+      vertex 10 17.3205 0
+      vertex 14.1421 14.1421 10
+      vertex 10 17.3205 10
+    endloop
+  endfacet
+  facet normal -0.608761 -0.793353 -0
+    outer loop
+      vertex 14.1421 14.1421 10
+      vertex 10 17.3205 0
+      vertex 14.1421 14.1421 0
+    endloop
+  endfacet
+  facet normal 0.608761 -0.793354 0
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -10 17.3205 10
+      vertex -14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal 0.608761 -0.793354 0
+    outer loop
+      vertex -10 17.3205 10
+      vertex -14.1421 14.1421 0
+      vertex -10 17.3205 0
+    endloop
+  endfacet
+  facet normal 0.793354 -0.608761 0
+    outer loop
+      vertex -17.3205 10 10
+      vertex -14.1421 14.1421 0
+      vertex -14.1421 14.1421 10
+    endloop
+  endfacet
+  facet normal 0.793354 -0.608761 0
+    outer loop
+      vertex -14.1421 14.1421 0
+      vertex -17.3205 10 10
+      vertex -17.3205 10 0
+    endloop
+  endfacet
+  facet normal 0.382683 -0.92388 0
+    outer loop
+      vertex -10 17.3205 0
+      vertex -5.17638 19.3185 10
+      vertex -10 17.3205 10
+    endloop
+  endfacet
+  facet normal 0.382683 -0.92388 0
+    outer loop
+      vertex -5.17638 19.3185 10
+      vertex -10 17.3205 0
+      vertex -5.17638 19.3185 0
+    endloop
+  endfacet
+  facet normal 0.608761 0.793353 -0
+    outer loop
+      vertex -10 -17.3205 0
+      vertex -14.1421 -14.1421 10
+      vertex -10 -17.3205 10
+    endloop
+  endfacet
+  facet normal 0.608761 0.793353 0
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -10 -17.3205 0
+      vertex -14.1421 -14.1421 0
     endloop
   endfacet
   facet normal -0.382683 -0.92388 0
@@ -19149,6 +19107,160 @@ solid OpenSCAD_Model
       vertex -17.3205 10 0
       vertex -19.3185 5.17638 10
       vertex -19.3185 5.17638 0
+    endloop
+  endfacet
+  facet normal 0.130526 -0.991445 0
+    outer loop
+      vertex -5.17638 19.3185 0
+      vertex 0 20 10
+      vertex -5.17638 19.3185 10
+    endloop
+  endfacet
+  facet normal 0.130526 -0.991445 0
+    outer loop
+      vertex 0 20 10
+      vertex -5.17638 19.3185 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -0.991445 0.130526 0
+    outer loop
+      vertex 19.3185 -5.17638 0
+      vertex 20 0 10
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal -0.991445 0.130526 0
+    outer loop
+      vertex 20 0 10
+      vertex 19.3185 -5.17638 0
+      vertex 19.3185 -5.17638 10
+    endloop
+  endfacet
+  facet normal -0.130526 0.991445 0
+    outer loop
+      vertex 5.17638 -19.3185 0
+      vertex 0 -20 10
+      vertex 5.17638 -19.3185 10
+    endloop
+  endfacet
+  facet normal -0.130526 0.991445 0
+    outer loop
+      vertex 0 -20 10
+      vertex 5.17638 -19.3185 0
+      vertex 0 -20 0
+    endloop
+  endfacet
+  facet normal -0.608761 0.793353 0
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 10 -17.3205 10
+      vertex 14.1421 -14.1421 10
+    endloop
+  endfacet
+  facet normal -0.608761 0.793353 0
+    outer loop
+      vertex 10 -17.3205 10
+      vertex 14.1421 -14.1421 0
+      vertex 10 -17.3205 0
+    endloop
+  endfacet
+  facet normal 0.382683 0.92388 -0
+    outer loop
+      vertex -5.17638 -19.3185 0
+      vertex -10 -17.3205 10
+      vertex -5.17638 -19.3185 10
+    endloop
+  endfacet
+  facet normal 0.382683 0.92388 0
+    outer loop
+      vertex -10 -17.3205 10
+      vertex -5.17638 -19.3185 0
+      vertex -10 -17.3205 0
+    endloop
+  endfacet
+  facet normal 0.793354 0.608761 0
+    outer loop
+      vertex -14.1421 -14.1421 10
+      vertex -17.3205 -10 0
+      vertex -17.3205 -10 10
+    endloop
+  endfacet
+  facet normal 0.793354 0.608761 0
+    outer loop
+      vertex -17.3205 -10 0
+      vertex -14.1421 -14.1421 10
+      vertex -14.1421 -14.1421 0
+    endloop
+  endfacet
+  facet normal 0.991445 0.130526 0
+    outer loop
+      vertex -19.3185 -5.17638 10
+      vertex -20 0 0
+      vertex -20 0 10
+    endloop
+  endfacet
+  facet normal 0.991445 0.130526 0
+    outer loop
+      vertex -20 0 0
+      vertex -19.3185 -5.17638 10
+      vertex -19.3185 -5.17638 0
+    endloop
+  endfacet
+  facet normal -0.382683 0.92388 0
+    outer loop
+      vertex 10 -17.3205 0
+      vertex 5.17638 -19.3185 10
+      vertex 10 -17.3205 10
+    endloop
+  endfacet
+  facet normal -0.382683 0.92388 0
+    outer loop
+      vertex 5.17638 -19.3185 10
+      vertex 10 -17.3205 0
+      vertex 5.17638 -19.3185 0
+    endloop
+  endfacet
+  facet normal -0.92388 0.382683 0
+    outer loop
+      vertex 17.3205 -10 0
+      vertex 19.3185 -5.17638 10
+      vertex 19.3185 -5.17638 0
+    endloop
+  endfacet
+  facet normal -0.92388 0.382683 0
+    outer loop
+      vertex 19.3185 -5.17638 10
+      vertex 17.3205 -10 0
+      vertex 17.3205 -10 10
+    endloop
+  endfacet
+  facet normal -0.793353 0.608761 0
+    outer loop
+      vertex 14.1421 -14.1421 0
+      vertex 17.3205 -10 10
+      vertex 17.3205 -10 0
+    endloop
+  endfacet
+  facet normal -0.793353 0.608761 0
+    outer loop
+      vertex 17.3205 -10 10
+      vertex 14.1421 -14.1421 0
+      vertex 14.1421 -14.1421 10
+    endloop
+  endfacet
+  facet normal 0.92388 0.382683 0
+    outer loop
+      vertex -17.3205 -10 10
+      vertex -19.3185 -5.17638 0
+      vertex -19.3185 -5.17638 10
+    endloop
+  endfacet
+  facet normal 0.92388 0.382683 0
+    outer loop
+      vertex -19.3185 -5.17638 0
+      vertex -17.3205 -10 10
+      vertex -17.3205 -10 0
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/generate_makefile.py
+++ b/generate_makefile.py
@@ -33,32 +33,32 @@ def body_parameters(version):
     p["motor_lugs"] = m.group(4)=="-M"
     p["sample_z"] = m.group(2)
     return p
-    
+
 def optics_module_parameters(version):
     """Figure out the parameters we need to generate the optics module"""
     m = re.search("({cam})_({lens})_({body})".format(
-                            cam="|".join(cameras), 
+                            cam="|".join(cameras),
                             lens="|".join(lenses),
-                            body="|".join(body_versions)), 
+                            body="|".join(body_versions)),
                         version)
     if m is None:
         raise ValueError("Error finding optics module parameters from version string '{}'".format(version))
     p = {"camera": m.group(1), "optics": m.group(2)}
     p.update(body_parameters(m.group(3)))
     return p
-	
+
 def stand_parameters(version):
 	m = re.match("({body})-([\d]+)$".format(body="|".join(body_versions)), version)
 	p = body_parameters(m.group(1))
 	p["h"] = int(m.group(2))
 	return p
-    
+
 def riser_parameters(version):
     """extract the parameters for sample risers"""
     m = re.match("(LS|SS)([\d]+)", version)
     p = {}
     p["big_stage"] = "LS" == m.group(1)
-    p["h"] = int(m.group(2))
+    p["riser_h"] = int(m.group(2))
     return p
 
 def openscad_recipe(**kwargs):
@@ -75,7 +75,7 @@ def openscad_recipe(**kwargs):
         output += " -D '{name}={value}'".format(name=name, value=str(value))
     output += " $<\n"
     return output
-    
+
 def merge_dicts(*args):
     """Merge dictionaries together into a single output."""
     out = args[0].copy()
@@ -87,15 +87,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate the Openflexure Microscope makefile")
     parser.add_argument("--version_numstring", help="Override the defined version string", default=None)
     args = parser.parse_args()
-    
+
     extra_defines = {}
     if args.version_numstring:
         extra_defines['version_numstring'] = args.version_numstring
-        
+
     def openscad_recipe_baked(**kwargs):
         """An openscad recipe, with additional definitions baked in."""
         return openscad_recipe(**merge_dicts(extra_defines, kwargs))
-    
+
     with open("Makefile","w") as makefile:
         def M(line):
             makefile.write(line + "\n")

--- a/openscad/main_body.scad
+++ b/openscad/main_body.scad
@@ -20,6 +20,7 @@ use <./z_axis.scad>;
 use <./gears.scad>;
 use <./wall.scad>;
 use <./main_body_transforms.scad>;
+use <./sample_riser.scad>
 include <./microscope_parameters.scad>; //All the geometric variables are now in here.
 
 
@@ -205,6 +206,10 @@ union(){
 		each_leg() translate([0,-zflex_l-4,flex_z2+1.5]) repeat([leg_middle_w/2,0,0],3,center=true) trylinder_selftap(3,h=999); //mounting holes
 	}
 	
+    if(merge_sample_riser)
+        translate([0,0,sample_z-0.1])
+            simple_riser(h=riser_h+0.1);
+
 	//z axis
     z_axis_flexures();
     z_axis_struts();

--- a/openscad/microscope_parameters.scad
+++ b/openscad/microscope_parameters.scad
@@ -67,6 +67,7 @@ version_string = str("v",version_numstring, big_stage?"-LS":"-SS", sample_z, mot
 echo(str("Compiling OpenFlexure Microscope ",version_string));
 
 stage_t=5; //thickness of the XY stage (at thickest point, most is 1mm less)
+riser_h=10;
 flex_z1 = 0;      // z position of lower flexures for XY axis
 flex_z2 = sample_z-stage_t; //height of upper XY flexures
 z_strut_t = 6;  // (z) thickness of struts for Z axis

--- a/openscad/microscope_parameters.scad
+++ b/openscad/microscope_parameters.scad
@@ -37,7 +37,7 @@ optics = "pilens"; //see optics.scad for valid values
 led_r = 5/2; //size of the LED used for illumination
 feet_endstops = true;
 beamsplitter = false; //enables a cut-out in some optics modules for a beamsplitter
-
+merge_sample_riser = false;
 
 // This sets the basic geometry of the microscope
 sample_z = big_stage?65:40; // height of the top of the stage

--- a/openscad/sample_riser.scad
+++ b/openscad/sample_riser.scad
@@ -20,9 +20,6 @@ include <microscope_parameters.scad>;
 
 $fn=24;
 
-h = 10;
-
-
 module simple_riser(h=10){
     // Make the stage thicker by height h, to raise up the slide
     // NB you'll need to raise the illumination too!
@@ -30,10 +27,14 @@ module simple_riser(h=10){
 		hull() each_leg() translate([0,-zflex_l-d,h/2]) cube([leg_middle_w+2*zflex_l,2*d,h],center=true); //hole in the stage
         cylinder(r=hole_r,h=999,center=true);
 		each_leg() reflect([1,0,0]) translate([leg_middle_w/2,-zflex_l-4,3.5]){
-            cylinder(r=3/2*1.2,h=999, center=true); //mounting holes
-            cylinder(r=3*1.2,h=999); //mounting holes
+            if(!merge_sample_riser){
+                cylinder(r=3/2*1.2,h=999, center=true); //mounting holes
+                cylinder(r=3*1.2,h=999);
+            }else{
+                trylinder_selftap(3,h=999,center=true);
+            }
         }
-        each_leg() translate([0,-zflex_l-4,0]) cylinder(r=3/2*0.95, h=999, center=true);
+        each_leg() translate([0,-zflex_l-4,0]) trylinder_selftap(3, h=999, center=true);
 	}
 }
-simple_riser(h=h);
+simple_riser(h=riser_h);

--- a/openscad/slide_riser.scad
+++ b/openscad/slide_riser.scad
@@ -20,7 +20,6 @@ sep = 26;
 $fn=24;
 
 slide = [75.8,25.8,1.0];
-h = 10;
 size = slide + [1,1,0]*8*2 + [0,0,h+1];
 clip_pivot = [20,size[1]/2+1,0];
 
@@ -29,42 +28,42 @@ module slide_riser(){
         union(){
             translate([-size[0],-size[1],0]/2) cube(size);
             hull(){
-                translate(clip_pivot) cylinder(r=5,h=h);
-                translate([clip_pivot[0],0,0]) cylinder(r=5,h=h);
+                translate(clip_pivot) cylinder(r=5,h=riser_h);
+                translate([clip_pivot[0],0,0]) cylinder(r=5,h=riser_h);
             }
         }
-        
+
         //cut-out for slide
-        hull() translate([-999/2,-slide[1]/2,h]){
+        hull() translate([-999/2,-slide[1]/2,riser_h]){
             translate(-[1,1,0]*slide[2]/2) cube([999,999,d]);
             translate([1,1,2]*999+[0,0,slide[2]]) cube([999,999,d]);
         }
-        
+
         //cut-out for middle of slide (immersion oil, etc.)
-        translate([-999/2,-slide[1]/2+2, h-2]) cube([999,slide[1]-4,999]);
-        
+        translate([-999/2,-slide[1]/2+2, riser_h-2]) cube([999,slide[1]-4,999]);
+
         //mounting holes
         reflect([1,0,0]) reflect([0,1,0]) rotate(-45) translate([leg_middle_w/2,leg_r-zflex_l-4,2]){
             cylinder(r=3/2*1.15,h=999,center=true); //mounting holes
             cylinder(r=3*1.15,h=999); //mounting holes
         }
-        
+
         //central hole
         cylinder(r=hole_r,h=999,center=true, $fn=32);
-        
+
         //mounting for clip
         translate(clip_pivot + [0,0,h-2]) cylinder(r=4,h=999);
         translate(clip_pivot + [0,0,0.5]) cylinder(d=3*0.95,h=999);
         //hole for spring
         translate(clip_pivot + [10,-4,h-5]) rotate([-75,0,0]) cylinder(d=4.5,h=999);
-        
+
         //mounting holes at the side
-        //translate([size[0]/2,0,h/2]) repeat([0,8,0], floor(size[1]/8-1), center=true){
+        //translate([size[0]/2,0,riser_h/2]) repeat([0,8,0], floor(size[1]/8-1), center=true){
         //   rotate([0,90,0]) cylinder(r=3/2*0.95, h=16,center=true);
         //}
-        
-    } 
-       
+
+    }
+
 }
 
 module slide_clip(){
@@ -72,14 +71,14 @@ module slide_clip(){
     difference(){
         union(){
             //this part contacts the slide
-            translate([0,slide[1]/2+1,h]) cylinder(r1=3,r2=5,h=2);
+            translate([0,slide[1]/2+1,riser_h]) cylinder(r1=3,r2=5,h=2);
             //this is the arm, incl. spring seat
-            translate([0,0,h]) add_hull_base(2){
+            translate([0,0,riser_h]) add_hull_base(2){
                 translate([0,slide[1]/2+1,0]) cylinder(r=2,h=2);
                 translate(clip_pivot + [0,0,0]) cylinder(r=3.7,h=2);
                 translate(clip_pivot + [10-1,travel+1.5,0]) cylinder(r=1.5,h=2);
                 translate(clip_pivot + [5+1,travel,-8]) cube([8,3,8+2]);
-                
+
                 //this stops it rotating too far
                 translate(clip_pivot) rotate(15){
                     translate([-5-3,size[1]/2 - clip_pivot[1],-2]) cube([3,3,4]);
@@ -91,7 +90,7 @@ module slide_clip(){
         //hole for pivot screw
         translate(clip_pivot) cylinder(d=3*1.1,h=999,center=true);
         //screw seat
-        translate(clip_pivot + [10,travel,h-4]) rotate([75,0,0]) cylinder(d=4.5,h=3,center=true);
+        translate(clip_pivot + [10,travel,riser_h-4]) rotate([75,0,0]) cylinder(d=4.5,h=3,center=true);
     }
 }
 use <main_body.scad>;
@@ -100,7 +99,7 @@ module simple_riser(h=10){
     // Make the stage thicker by height h, to raise up the slide
     // NB you'll need to raise the illumination too!
     difference(){
-		hull() each_leg() translate([0,-zflex_l-d,h/2]) cube([leg_middle_w+2*zflex_l,2*d,h],center=true); //hole in the stage
+		hull() each_leg() translate([0,-zflex_l-d,riser_h/2]) cube([leg_middle_w+2*zflex_l,2*d,riser_h],center=true); //hole in the stage
         cylinder(r=hole_r,h=999,center=true);
 		each_leg() reflect([1,0,0]) translate([leg_middle_w/2,-zflex_l-4,3.5]){
             cylinder(r=3/2*1.2,h=999, center=true); //mounting holes
@@ -111,6 +110,6 @@ module simple_riser(h=10){
 }
 //simple_riser();
 slide_riser();
-translate([-25,10,h+2]) translate(clip_pivot) rotate([180,0,22]) translate(-clip_pivot) slide_clip();
-//rotate([180,0,0]) 
+translate([-25,10,riser_h+2]) translate(clip_pivot) rotate([180,0,22]) translate(-clip_pivot) slide_clip();
+//rotate([180,0,0])
 //slide_clip();


### PR DESCRIPTION
Printing the sample riser and main body separately can cause slight deformation in the riser due to printing errors (edges detach from the bed) and it can be difficult to assemble so that it is exactly flat on the table. Depth of field is quite small with the 100x objective (~300nm), so it needs to be assembled to within ~0.1mm have the entire field in focus.
This adds an option to microscope_parameters to print the riser together with the main body and changes the shape of the clamp holes to trilinders.